### PR TITLE
Add login/logout functionality with session management and templates

### DIFF
--- a/development.ini
+++ b/development.ini
@@ -25,6 +25,8 @@ retry.attempts = 3
 # '127.0.0.1' and '::1'.
 # debugtoolbar.hosts = 127.0.0.1 ::1
 
+auth.secret =
+
 [pshell]
 setup = honeycomb.pshell.setup
 

--- a/honeycomb/__init__.py
+++ b/honeycomb/__init__.py
@@ -1,4 +1,5 @@
 from pyramid.config import Configurator
+from pyramid.session import SignedCookieSessionFactory
 from pyramid_zodbconn import get_connection
 
 from .models import appmaker
@@ -13,11 +14,18 @@ def main(global_config, **settings):
     """ This function returns a Pyramid WSGI application.
     """
     with Configurator(settings=settings) as config:
+        assert settings['auth.secret'], "Please make sure to provide a cryptographically strong secret to store session information"
+        session_factory = SignedCookieSessionFactory(settings['auth.secret'],
+                                   secure=False,
+                                   httponly=True)
+        config.set_session_factory(session_factory)
+        # config.set_security_policy(SecurityPolicy(secret=settings['auth.secret']))
         config.include('pyramid_jinja2')
         config.include('pyramid_tm')
         config.include('pyramid_retry')
         config.include('pyramid_zodbconn')
         config.include('.routes')
+        config.include('.security')
         config.include('cornice')
         config.set_root_factory(root_factory)
         config.scan()

--- a/honeycomb/templates/beehive.jinja2
+++ b/honeycomb/templates/beehive.jinja2
@@ -4,8 +4,8 @@
 <div class="content">
   <h1><span class="font-semi-bold">{{ project }}</span></h1>
   <p class="lead">
-    Welcome to the BeeHive. You are currently visiting
-    <span class="font-normal">{{ title }}</span>.
+      Welcome to the BeeHive{% if request.authenticated_userid %}: <span class="text-info">{{ request.identity["displayname"] }}</span>{% endif %}. You are currently visiting
+    <span class="font-normal">{{ title or "Demo Beehive" }}</span>.
     Please look at the contents which are here available.
   </p>
 

--- a/honeycomb/templates/login.jinja2
+++ b/honeycomb/templates/login.jinja2
@@ -1,0 +1,24 @@
+{% extends "layout.jinja2" %}
+
+{% block header %}
+    <div class="header row">
+        <div class="col text-center">
+             <h2><span class="font-semi-bold">Log in</span></h2>
+        </div>
+    </div>
+{% endblock %}
+
+{% block content %}
+<div class="content row">
+    <div class="col-md-8">
+      {% if login_form %}
+         {{ login_form|safe }}
+      {% else %}
+          <form><input type="submit" value="login"></form>
+      {% endif %}
+      {% if appstruct %}
+      {{ appstruct }}
+      {% endif %}
+    </div>
+</div>
+{% endblock content %}

--- a/honeycomb/views/auth.py
+++ b/honeycomb/views/auth.py
@@ -1,0 +1,41 @@
+from pyramid.csrf import new_csrf_token
+from pyramid.httpexceptions import HTTPSeeOther, HTTPNotFound
+from pyramid.security import (
+    remember,
+    forget,
+    NO_PERMISSION_REQUIRED,
+)
+
+from pyramid.view import (
+    forbidden_view_config,
+    view_config,
+)
+
+from deform import Form, ValidationFailure, Button
+
+from .. import security
+from .. import models
+
+
+@view_config(name="login", context=models.BeeHive, renderer='templates/login.jinja2')
+@forbidden_view_config(renderer='templates/login.jinja2')
+def login_view(context, request):
+    next_url = request.params.get('next', request.referrer)
+    login_url = '/login'
+    if not next_url or next_url == login_url:
+        next_url = "/"
+
+    if request.identity:
+        return HTTPSeeOther(location=next_url)
+    else:
+        new_csrf_token(request)
+        headers = remember(request, 'convida@unam.social')
+        return HTTPSeeOther(location=next_url, headers=headers)
+
+@view_config(name='logout', context=models.BeeHive)
+def logout_view(context, request):
+    assert request.identity
+    next_url = "/"
+    new_csrf_token(request)
+    headers = forget(request)
+    return HTTPSeeOther(location=next_url, headers=headers)


### PR DESCRIPTION
Introduced login and logout views, including a login template. Added session management using `SignedCookieSessionFactory`, requiring an `auth.secret` configuration. Updated `beehive.jinja2` for dynamic user greetings.

Closes #24 