### PR TITLE
issue #23

### DIFF
--- a/honeycomb/models/__init__.py
+++ b/honeycomb/models/__init__.py
@@ -150,17 +150,7 @@ def appmaker(zodb_root):
         abejas[mapa.__name__] = mapa
         app_root.add_node(mapa)
 
-        # reproduccion = mapa['node-24542b5b-ece1-45fa-975e-6c54744e1630']
-        # Buscar el nodo por id dentro de los valores de mapa
-        reproduccion = None
-        reproduccion_id = "node-24542b5b-ece1-45fa-975e-6c54744e1630"
-        for node in mapa.values():
-            # Buscar por atributo id o __name__
-            if getattr(node, "id", None) == reproduccion_id or getattr(node, "__name__", None) == reproduccion_id:
-                reproduccion = node
-                break
-        if reproduccion is None:
-            raise KeyError(f"No se encontró el nodo de reproducción con id {reproduccion_id}. Nodos disponibles: {[getattr(n, 'id', getattr(n, '__name__', None)) for n in mapa.values()]}")
+        reproduccion = mapa['reproducción']
 
         with open("honeycomb/static/assets/grafo_reproduccion.json") as f:
             grafo = HoneycombGraph.from_json(f.read(), name="ciclo-reproductivo", title="Ciclo reproductivo")

--- a/honeycomb/views/api.py
+++ b/honeycomb/views/api.py
@@ -148,10 +148,13 @@ class DroneResource:
 
     def get(self):
         user = getattr(self.request, 'identity', None)
+        url_userid = self.request.matchdict.get('userid')
         if not user:
             self.request.response.status = 401
             return {'error': 'Unauthorized'}
-
+        if url_userid != user.get('userid'):
+            self.request.response.status = 403
+            return {'error': 'Forbidden: userid mismatch'}
         return {
             'userid': user.get('userid'),
             'displayname': user.get('displayname'),


### PR DESCRIPTION
Implementación y prueba de los endpoints `/api/v1/drones/{userid}` y `/api/v1/sipping/{nodeid}` para manejo de datos personalizados de usuario y nodos.
Corrección en la obtención de datos de usuario autenticado en los endpoints (uso de user.get()).