### PR TITLE
Traversal CRUD API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *~
 .coverage
 coverage.xml
+blobs/
 build/
 dist/
 .tox/

--- a/development.ini
+++ b/development.ini
@@ -17,7 +17,7 @@ pyramid.includes =
 storage.base_path = %(here)s/honeycomb/static/uploads/
 storage.base_url = /static/uploads/
 
-zodbconn.uri = file://%(here)s/Data.fs?connection_cache_size=20000
+zodbconn.uri = file://%(here)s/Data.fs?connection_cache_size=20000&blobstorage_dir=%(here)s/blobs
 
 retry.attempts = 3
 

--- a/honeycomb/forms/__init__.py
+++ b/honeycomb/forms/__init__.py
@@ -1,0 +1,1 @@
+from .cells import *

--- a/honeycomb/forms/cells.py
+++ b/honeycomb/forms/cells.py
@@ -1,0 +1,9 @@
+import colander
+import deform
+
+
+class AudioCellSchema(colander.MappingSchema):
+    title = colander.SchemaNode(colander.String(), missing="")
+    # data = colander.SchemaNode(deform.schema.FileData())
+    mimetype = colander.SchemaNode(colander.String(), validator=colander.OneOf(['audio/mpeg', 'audio/aac', 'audio/ogg', 'audio/wav', 'audio/flac'], msg_err='"${val}" must be one of ${choices}'))
+    parent = colander.SchemaNode(colander.String(), validator=colander.uuid, missing=None)

--- a/honeycomb/models/beehive.py
+++ b/honeycomb/models/beehive.py
@@ -351,6 +351,18 @@ class CellAnimation(CellLeaf):
         return self.icon
 
 
+class CellAudio(CellLeaf):
+    """Contains audio metadata and binary blob"""
+    def __init__(self, name, data, mime, length=0, title="", icon=None):
+        super().__init__(self)
+        self.__name__ = name
+        self.title = title
+        self.data = data
+        self.icon = icon
+        self.mime = mime
+        self.length = length
+
+
 class CellWebContent(CellLeaf):
     def __init__(self, name, url, title="", icon=None):
         super().__init__(self)

--- a/honeycomb/models/beehive.py
+++ b/honeycomb/models/beehive.py
@@ -87,12 +87,20 @@ class Honeycomb(PersistentMapping):
         self.icon = None
         self.map = None
 
+    def __setitem__(self, key, value):
+        """Asigna item y actualiza __parent__ y __name__"""
+        super().__setitem__(key, value)
+        if hasattr(value, '__parent__'):
+            value.__parent__ = self
+        if hasattr(value, '__name__'):
+            value.__name__ = key
+    
     def set_map(self, honeycombmap):
         self.map = honeycombmap
 
     def get_map(self):
         return self.map
-
+    
 class CellEdge(Persistent):
     def __init__(self, name, title, from_node, to_node, kind="default"):
         self.name = name
@@ -268,7 +276,7 @@ class HoneyDynamicMap(CellLeaf):
 class InteractiveCell(CellLeaf):
     """A BeeHive cell containing an interactive element"""
     def __init__(self, name, title=""):
-        super().__init__(self)
+        super().__init__(name=name, title=title)
         self.__name__ = name
         self.title = title
         self.icon = None
@@ -277,7 +285,7 @@ class InteractiveCell(CellLeaf):
 class StaticCell(CellLeaf):
     """A BeeHive cell containing static elements"""
     def __init__(self, name, title=""):
-        super().__init__(self)
+        super().__init__(name=name, title=title)
         self.__name__ = name
         self.title = title
         self.icon = None
@@ -286,7 +294,7 @@ class StaticCell(CellLeaf):
 class CellIcon(CellLeaf):
     """A BeeHive cell icon."""
     def __init__(self, name, title="", icon=None):
-        super().__init__(self)
+        super().__init__(name=name, title=title)
         self.__name__ = name
         self.title = title
         self.icon = icon
@@ -300,7 +308,7 @@ class CellIcon(CellLeaf):
 
 class CellText(CellLeaf):
     def __init__(self, name, contents, title="", icon=None):
-        super().__init__(self)
+        super().__init__(name=name, title=title)
         self.__name__ = name
         self.title = title
         self.contents = contents
@@ -323,7 +331,7 @@ class CellText(CellLeaf):
 
 class CellRichText(CellLeaf):
     def __init__(self, name, contents, title="", icon=None):
-        super().__init__(self)
+        super().__init__(name=name, title=title)
         self.__name__ = name
         self.title = title
         self.source = contents
@@ -338,7 +346,7 @@ class CellRichText(CellLeaf):
 
 class CellAnimation(CellLeaf):
     def __init__(self, name, url, title="", icon=None):
-        super().__init__(self)
+        super().__init__(name=name, title=title)
         self.__name__ = name
         self.href = url
         self.title = title
@@ -354,7 +362,7 @@ class CellAnimation(CellLeaf):
 class CellAudio(CellLeaf):
     """Contains audio metadata and binary blob"""
     def __init__(self, name, data, mime, length=0, title="", icon=None):
-        super().__init__(self)
+        super().__init__(name=name, title=title)
         self.__name__ = name
         self.title = title
         self.data = data
@@ -365,7 +373,7 @@ class CellAudio(CellLeaf):
 
 class CellWebContent(CellLeaf):
     def __init__(self, name, url, title="", icon=None):
-        super().__init__(self)
+        super().__init__(name=name, title=title)
         self.__name__ = name
         self.href = url
         self.title = title

--- a/honeycomb/models/beehive.py
+++ b/honeycomb/models/beehive.py
@@ -3,6 +3,7 @@ from persistent import Persistent
 from persistent.mapping import PersistentMapping
 from BTrees._OOBTree import OOBTree
 from persistent.list import PersistentList
+from slugify import slugify
 import json, uuid
 
 class BeeHive(PersistentMapping):
@@ -14,7 +15,7 @@ class BeeHive(PersistentMapping):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.id = str(uuid.uuid4())
+        self.id = uuid.uuid4()
         self.title = "BeeHive Root"
         self.__nodes__ = OOBTree()
         self.__edges__ = OOBTree()
@@ -81,7 +82,7 @@ class Honeycomb(PersistentMapping):
 
     def __init__(self, name, title=""):
         PersistentMapping.__init__(self)
-        self.id = str(uuid.uuid4())
+        self.id = uuid.uuid4()
         self.__name__ = name
         self.title = title
         self.icon = None
@@ -226,24 +227,34 @@ class CellLeaf(Persistent):
     """A terminal node in the honeycomb structure, it cannot have children nodes."""
     def __init__(self, name="", parent=None, title=""):
         super().__init__()
-        self.__name__ = name
+        # Cada nodo tiene un ID único y persistente
+        self.id = uuid.uuid4()
+        if name:
+            self.__name__ = name
+        elif title:
+            self.__name__ = slugify(title)
+        else:
+            self.__name__ = self.id.hex
         self.__parent__ = parent
         self.title = title
         self.icon = None
-        # Cada nodo tiene un ID único y persistente
-        self.id = uuid.uuid4()
 
 
 class CellNode(PersistentMapping):
     """A node in the honeycomb structure, it can contain children nodes or be alone, it can also be static or interactive."""
     def __init__(self, name="", parent=None, title=""):
         super().__init__()
-        self.__name__ = name
+        # Cada nodo tiene un ID único y persistente
+        self.id = uuid.uuid4()
+        if name:
+            self.__name__ = name
+        elif title:
+            self.__name__ = slugify(title)
+        else:
+            self.__name__ = self.id.hex
         self.__parent__ = parent
         self.title = title
         self.icon = None
-        # Cada nodo tiene un ID único y persistente
-        self.id = uuid.uuid4()
 
     def set_icon(self, icon):
         self.icon = icon
@@ -363,8 +374,6 @@ class CellAudio(CellLeaf):
     """Contains audio metadata and binary blob"""
     def __init__(self, name, data, mime, length=0, title="", icon=None):
         super().__init__(name=name, title=title)
-        self.__name__ = name
-        self.title = title
         self.data = data
         self.icon = icon
         self.mime = mime

--- a/honeycomb/views/default.py
+++ b/honeycomb/views/default.py
@@ -3,6 +3,7 @@ from pyramid.httpexceptions import HTTPSeeOther, HTTPFound
 from pyramid_storage.exceptions import FileNotAllowed
 from pyramid_storage import extensions
 from pyramid import traversal
+from pyramid.response import FileIter
 
 from ..models import *
 
@@ -52,6 +53,7 @@ def honeycomb_update(request):
     return HTTPSeeOther(request.resource_url(request.context))
 
 
+# New (REST-ful and traversal-compatible) style views
 @view_config(context=Honeycomb, name='matrix', renderer='json')
 def honeycomb_matrix(request):
     "This view returns a copy of the honeycomb distance matrix triggering its calculation if it isn't already available."
@@ -63,6 +65,27 @@ def honeycomb_matrix(request):
         return matrix.tolist()
 
 
+@view_config(context=CellAudio, renderer='json', request_method="GET", xhr=True)
+def audio_metadata_view(request):
+    cell = request.context
+    if not cell.title:
+        title = cell.name.title()
+    else:
+        title = cell.title
+    return {'title': title, 'id': cell.id.hex, 'length': cell.length, 'mime-type': cell.mime, 'stream_url': request.resource_url(cell)+"stream"}
+
+
+@view_config(context=CellAudio, name="stream", renderer='json', request_method="GET")
+def audio_stream_view(request):
+    cell = request.context
+    response = request.response
+    response.content_type = cell.mime
+    response.app_iter = FileIter(cell.data.open("r"))
+
+    return response
+
+
+# Old style views (deprecated)
 @view_config(context=CellText, renderer='honeycomb:templates/cell.jinja2')
 def textcell(request):
     if hasattr(request.context, 'title'):
@@ -111,7 +134,6 @@ def edit_cell_text(context, request):
     return {"cell": context}
 
 
-# Vistas Nuevas
 @view_config(context=CellRichText, renderer='honeycomb:templates/cell.jinja2')
 def richtextcell(request):
     title = getattr(request.context, 'title', "Wild cell")
@@ -151,6 +173,7 @@ def edit_cell_animation(context, request):
         context.icon = request.params.get('icon', context.icon)
         return HTTPFound(location=request.resource_url(context))
     return {"cell": context}
+
 
 @view_config(context=CellWebContent, renderer='honeycomb:templates/view_cell_webcontent.jinja2')
 def webcell(context, request):

--- a/honeycomb/views/default.py
+++ b/honeycomb/views/default.py
@@ -303,7 +303,7 @@ def admin_create_node(context, request):
     titulo = data.get('titulo')
     
     if not tipo or not nombre:
-        return {'Faltan campos: tipo, nombre'}
+        return {'error': 'Faltan campos obligatorios: tipo, nombre'}
     
     if tipo == 'audio':
         nuevo = CellWebContent(nombre, data.get('url', ''), titulo)
@@ -316,10 +316,16 @@ def admin_create_node(context, request):
     elif tipo == 'texto':
         nuevo = CellText(nombre, data.get('contenido', ''), titulo)
     else:
-        return {'Tipo "{tipo}" no válido'}
+        return {'error': f'Tipo "{tipo}" no válido'}
     
     context[nombre] = nuevo
     
+    # Guardar en BeeHive para evitar que un nodo quede huérfano
+    beehive = traversal.find_root(context)
+    if hasattr(beehive, 'add_node'):
+        beehive.add_node(nuevo)
+    
+    request.response.status_int = 201
     return {
         'status': 'creado',
         'id': str(nuevo.id),
@@ -328,7 +334,7 @@ def admin_create_node(context, request):
     }
 
 #Actualizar
-@view_config(context=CellWebContent, name='admin', permission='read', renderer='json', request_method='POST')
+@view_config(context=CellWebContent, name='admin', permission='read', renderer='json', request_method='PUT')
 def admin_update_webcontent(context, request):
     """Actualizar audio o video"""
     data = request.json_body
@@ -338,7 +344,7 @@ def admin_update_webcontent(context, request):
         context.href = data['url']
     return {'status': 'actualizado', 'id': str(context.id)}
 
-@view_config(context=CellIcon, name='admin', permission='read', renderer='json', request_method='POST')
+@view_config(context=CellIcon, name='admin', permission='read', renderer='json', request_method='PUT')
 def admin_update_icon(context, request):
     """Actualizar imagen"""
     data = request.json_body
@@ -348,7 +354,7 @@ def admin_update_icon(context, request):
         context.icon = data['icono']
     return {'status': 'actualizado', 'id': str(context.id)}
 
-@view_config(context=CellText, name='admin', permission='read', renderer='json', request_method='POST')
+@view_config(context=CellText, name='admin', permission='read', renderer='json', request_method='PUT')
 def admin_update_text(context, request):
     """Actualizar texto"""
     data = request.json_body
@@ -358,7 +364,7 @@ def admin_update_text(context, request):
         context.contents = data['contenido']
     return {'status': 'actualizado', 'id': str(context.id)}
 
-@view_config(context=CellAnimation, name='admin', permission='read', renderer='json', request_method='POST')
+@view_config(context=CellAnimation, name='admin', permission='read', renderer='json', request_method='PUT')
 def admin_update_animation(context, request):
     """Actualizar animación"""
     data = request.json_body
@@ -369,14 +375,20 @@ def admin_update_animation(context, request):
     return {'status': 'actualizado', 'id': str(context.id)}
 
 #Eliminar
-@view_config(context=CellLeaf, name='admin', permission='read', renderer='json', request_method='POST')
+@view_config(context=CellLeaf, name='admin', permission='read', renderer='json', request_method='DELETE')
 def admin_delete_node(context, request):
     """Eliminar cualquier tipo de nodo"""
     parent = context.__parent__
     name = context.__name__
     
     if parent and name in parent:
+        beehive = traversal.find_root(context)
+        if hasattr(beehive, 'remove_node'):
+            node_id = str(getattr(context, "id", "")) or name
+            beehive.remove_node(node_id)
+            
         del parent[name]
         return {'status': 'eliminado', 'id': str(context.id)}
     
-    return {'No se pudo eliminar el nodo'}
+    request.response.status_int = 404
+    return {'error': 'No se pudo eliminar el nodo o ya no existe'}

--- a/honeycomb/views/default.py
+++ b/honeycomb/views/default.py
@@ -1,5 +1,5 @@
 from pyramid.view import view_config
-from pyramid.httpexceptions import HTTPSeeOther, HTTPFound
+from pyramid.httpexceptions import HTTPSeeOther, HTTPFound, HTTPBadRequest
 from pyramid_storage.exceptions import FileNotAllowed
 from pyramid_storage import extensions
 from pyramid import traversal
@@ -7,7 +7,11 @@ import uuid
 from pyramid.response import FileIter
 from pyramid.httpexceptions import HTTPBadRequest
 
+from ZODB.blob import Blob
+import os.path
+
 from ..models import *
+from ..forms import *
 
 
 @view_config(context=BeeHive, renderer='templates/beehive.jinja2')
@@ -64,6 +68,49 @@ def honeycomb_matrix(request):
             request.context.__explorer__.update_matrix()
             matrix = request.context.__explorer__.matrix
         return matrix.tolist()
+
+
+@view_config(context=Honeycomb, name="audio", renderer='json', request_method="POST", require_csrf=True)
+def audio_create_view(request):
+    schema = AudioCellSchema()
+    try:
+        fields = schema.deserialize(request.POST)
+    except colander.Invalid as err:
+        request.response.status = 400
+        return err.asdict()
+
+    filename = os.path.basename(request.POST['data'].filename)
+    source = request.POST['data'].file
+
+    parent_uuid = fields['parent']
+    title = fields['title']
+
+    # Improve this by adding both node and edge indexes to each Honeycomb instance
+    root = request.context.__parent__
+    parent = root.__nodes__.get(parent_uuid, None)
+    if parent:
+        path = traversal.resource_path_tuple(parent)
+
+        if not path or path[1] != request.self.context.__name__:
+            raise HTTPBadRequest("Parent ID does not belong to this Honeycomb")
+    else:
+        parent = request.context
+
+    audio = Blob()
+    length = 0
+    source.seek(0)
+
+    with audio.open('w') as target:
+        while True:
+            b = source.read(4096)
+            if b:
+                length += target.write(b)
+            else:
+                break
+
+    cell = CellAudio(name="", data=audio, title=fields['title'], mime=fields['mimetype'], length=length)
+    cell.__parent__ = parent
+    parent[cell.__name__] = cell
 
 
 @view_config(context=CellText, renderer='honeycomb:templates/cell.jinja2')

--- a/honeycomb/views/default.py
+++ b/honeycomb/views/default.py
@@ -3,7 +3,9 @@ from pyramid.httpexceptions import HTTPSeeOther, HTTPFound
 from pyramid_storage.exceptions import FileNotAllowed
 from pyramid_storage import extensions
 from pyramid import traversal
+import uuid
 from pyramid.response import FileIter
+from pyramid.httpexceptions import HTTPBadRequest
 
 from ..models import *
 
@@ -53,7 +55,6 @@ def honeycomb_update(request):
     return HTTPSeeOther(request.resource_url(request.context))
 
 
-# New (REST-ful and traversal-compatible) style views
 @view_config(context=Honeycomb, name='matrix', renderer='json')
 def honeycomb_matrix(request):
     "This view returns a copy of the honeycomb distance matrix triggering its calculation if it isn't already available."
@@ -65,27 +66,6 @@ def honeycomb_matrix(request):
         return matrix.tolist()
 
 
-@view_config(context=CellAudio, renderer='json', request_method="GET", xhr=True)
-def audio_metadata_view(request):
-    cell = request.context
-    if not cell.title:
-        title = cell.name.title()
-    else:
-        title = cell.title
-    return {'title': title, 'id': cell.id.hex, 'length': cell.length, 'mime-type': cell.mime, 'stream_url': request.resource_url(cell)+"stream"}
-
-
-@view_config(context=CellAudio, name="stream", renderer='json', request_method="GET")
-def audio_stream_view(request):
-    cell = request.context
-    response = request.response
-    response.content_type = cell.mime
-    response.app_iter = FileIter(cell.data.open("r"))
-
-    return response
-
-
-# Old style views (deprecated)
 @view_config(context=CellText, renderer='honeycomb:templates/cell.jinja2')
 def textcell(request):
     if hasattr(request.context, 'title'):
@@ -134,6 +114,7 @@ def edit_cell_text(context, request):
     return {"cell": context}
 
 
+# Vistas Nuevas
 @view_config(context=CellRichText, renderer='honeycomb:templates/cell.jinja2')
 def richtextcell(request):
     title = getattr(request.context, 'title', "Wild cell")
@@ -173,7 +154,6 @@ def edit_cell_animation(context, request):
         context.icon = request.params.get('icon', context.icon)
         return HTTPFound(location=request.resource_url(context))
     return {"cell": context}
-
 
 @view_config(context=CellWebContent, renderer='honeycomb:templates/view_cell_webcontent.jinja2')
 def webcell(context, request):
@@ -237,3 +217,166 @@ def honeycomb_graph_view(context, request):
         "nodes": nodes,
         "edges": edges
     }
+
+
+@view_config(context=CellAudio, renderer='json', request_method="GET", xhr=True)
+def audio_metadata_view(request):
+    """Obtener metadatos del audio"""
+    cell = request.context
+    if not cell.title:
+        title = cell.__name__.title() if cell.__name__ else "Audio"
+    else:
+        title = cell.title
+    return {
+        'title': title,
+        'id': cell.id.hex if hasattr(cell.id, 'hex') else str(cell.id),
+        'length': cell.length,
+        'mime-type': cell.mime,
+        'stream_url': request.resource_url(cell) + "stream"
+    }
+
+@view_config(context=CellAudio, name="stream", request_method="GET")
+def audio_stream_view(request):
+    """Reproducir audio"""
+    cell = request.context
+    response = request.response
+    response.content_type = cell.mime
+    response.app_iter = FileIter(cell.data.open("r"))
+    return response
+
+
+@view_config(context=CellIcon, renderer='json', request_method="GET", xhr=True)
+def image_metadata_view(request):
+    """Obtener metadatos de imagen"""
+    cell = request.context
+    return {
+        'id': str(cell.id),
+        'titulo': cell.title or cell.__name__,
+        'icono': cell.icon,
+        'tipo': 'imagen'
+    }
+
+
+@view_config(context=CellText, renderer='json', request_method="GET", xhr=True)
+def text_metadata_view(request):
+    """Obtener metadatos de texto"""
+    cell = request.context
+    return {
+        'id': str(cell.id),
+        'titulo': cell.title or cell.__name__,
+        'contenido': cell.contents,
+        'tipo': 'texto'
+    }
+
+
+@view_config(context=CellAnimation, renderer='json', request_method="GET", xhr=True)
+def animation_metadata_view(request):
+    """Obtener metadatos de animación"""
+    cell = request.context
+    return {
+        'id': str(cell.id),
+        'titulo': cell.title or cell.__name__,
+        'url': cell.href,
+        'tipo': 'animacion'
+    }
+
+
+@view_config(context=CellWebContent, renderer='json', request_method="GET", xhr=True)
+def webcontent_metadata_view(request):
+    """Obtener metadatos de contenido web"""
+    cell = request.context
+    return {
+        'id': str(cell.id),
+        'titulo': cell.title or cell.__name__,
+        'url': cell.href,
+        'tipo': 'webcontent'
+    }
+
+
+#Crear
+@view_config(context=Honeycomb, name='admin', permission='read', renderer='json', request_method='POST')
+def admin_create_node(context, request):
+    """Crear un nuevo nodo dentro de un honeycomb"""
+    data = request.json_body
+    tipo = data.get('tipo')
+    nombre = data.get('nombre')
+    titulo = data.get('titulo')
+    
+    if not tipo or not nombre:
+        return {'Faltan campos: tipo, nombre'}
+    
+    if tipo == 'audio':
+        nuevo = CellWebContent(nombre, data.get('url', ''), titulo)
+    elif tipo == 'video':
+        nuevo = CellWebContent(nombre, data.get('url', ''), titulo)
+    elif tipo == 'imagen':
+        nuevo = CellIcon(nombre, titulo, data.get('icono'))
+    elif tipo == 'animacion':
+        nuevo = CellAnimation(nombre, data.get('url', ''), titulo)
+    elif tipo == 'texto':
+        nuevo = CellText(nombre, data.get('contenido', ''), titulo)
+    else:
+        return {'Tipo "{tipo}" no válido'}
+    
+    context[nombre] = nuevo
+    
+    return {
+        'status': 'creado',
+        'id': str(nuevo.id),
+        'nombre': nombre,
+        'url': request.resource_url(nuevo)
+    }
+
+#Actualizar
+@view_config(context=CellWebContent, name='admin', permission='read', renderer='json', request_method='POST')
+def admin_update_webcontent(context, request):
+    """Actualizar audio o video"""
+    data = request.json_body
+    if 'titulo' in data:
+        context.title = data['titulo']
+    if 'url' in data:
+        context.href = data['url']
+    return {'status': 'actualizado', 'id': str(context.id)}
+
+@view_config(context=CellIcon, name='admin', permission='read', renderer='json', request_method='POST')
+def admin_update_icon(context, request):
+    """Actualizar imagen"""
+    data = request.json_body
+    if 'titulo' in data:
+        context.title = data['titulo']
+    if 'icono' in data:
+        context.icon = data['icono']
+    return {'status': 'actualizado', 'id': str(context.id)}
+
+@view_config(context=CellText, name='admin', permission='read', renderer='json', request_method='POST')
+def admin_update_text(context, request):
+    """Actualizar texto"""
+    data = request.json_body
+    if 'titulo' in data:
+        context.title = data['titulo']
+    if 'contenido' in data:
+        context.contents = data['contenido']
+    return {'status': 'actualizado', 'id': str(context.id)}
+
+@view_config(context=CellAnimation, name='admin', permission='read', renderer='json', request_method='POST')
+def admin_update_animation(context, request):
+    """Actualizar animación"""
+    data = request.json_body
+    if 'titulo' in data:
+        context.title = data['titulo']
+    if 'url' in data:
+        context.href = data['url']
+    return {'status': 'actualizado', 'id': str(context.id)}
+
+#Eliminar
+@view_config(context=CellLeaf, name='admin', permission='read', renderer='json', request_method='POST')
+def admin_delete_node(context, request):
+    """Eliminar cualquier tipo de nodo"""
+    parent = context.__parent__
+    name = context.__name__
+    
+    if parent and name in parent:
+        del parent[name]
+        return {'status': 'eliminado', 'id': str(context.id)}
+    
+    return {'No se pudo eliminar el nodo'}

--- a/production.ini
+++ b/production.ini
@@ -12,9 +12,11 @@ pyramid.debug_notfound = false
 pyramid.debug_routematch = false
 pyramid.default_locale_name = en
 
-zodbconn.uri = file://%(here)s/Data.fs?connection_cache_size=20000
+zodbconn.uri = file://%(here)s/Data.fs?connection_cache_size=20000&blobstorage_dir=%(here)s/blobs
 
 retry.attempts = 3
+
+auth.secret =
 
 [pshell]
 setup = honeycomb.pshell.setup

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "pyramid-storage>=1.3.2",
     "pyramid-tm>=2.6",
     "pyramid-zodbconn>=0.8.1",
+    "python-slugify>=8.0.4",
     "scipy>=1.16.3",
     "transaction>=5.0",
     "waitress>=3.0.2",

--- a/uv.lock
+++ b/uv.lock
@@ -256,6 +256,7 @@ dependencies = [
     { name = "pyramid-storage" },
     { name = "pyramid-tm" },
     { name = "pyramid-zodbconn" },
+    { name = "python-slugify" },
     { name = "scipy" },
     { name = "transaction" },
     { name = "waitress" },
@@ -285,6 +286,7 @@ requires-dist = [
     { name = "pyramid-storage", specifier = ">=1.3.2" },
     { name = "pyramid-tm", specifier = ">=2.6" },
     { name = "pyramid-zodbconn", specifier = ">=0.8.1" },
+    { name = "python-slugify", specifier = ">=8.0.4" },
     { name = "scipy", specifier = ">=1.16.3" },
     { name = "transaction", specifier = ">=5.0" },
     { name = "waitress", specifier = ">=3.0.2" },
@@ -757,6 +759,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-slugify"
+version = "8.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "text-unidecode" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/c7/5e1547c44e31da50a460df93af11a535ace568ef89d7a811069ead340c4a/python-slugify-8.0.4.tar.gz", hash = "sha256:59202371d1d05b54a9e7720c5e038f928f45daaffe41dd10822f3907b937c856", size = 10921, upload-time = "2024-02-08T18:32:45.488Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl", hash = "sha256:276540b79961052b66b7d116620b36518847f52d5fd9e3a70164fc8c50faa6b8", size = 10051, upload-time = "2024-02-08T18:32:43.911Z" },
+]
+
+[[package]]
 name = "rich"
 version = "14.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -846,6 +860,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6d/e6/21ccce3262dd4889aa3332e5a119a3491a95e8f60939870a3a035aabac0d/soupsieve-2.8.tar.gz", hash = "sha256:e2dd4a40a628cb5f28f6d4b0db8800b8f581b65bb380b97de22ba5ca8d72572f", size = 103472, upload-time = "2025-08-27T15:39:51.78Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/a0/bb38d3b76b8cae341dad93a2dd83ab7462e6dbcdd84d43f54ee60a8dc167/soupsieve-2.8-py3-none-any.whl", hash = "sha256:0cc76456a30e20f5d7f2e14a98a4ae2ee4e5abdc7c5ea0aafe795f344bc7984c", size = 36679, upload-time = "2025-08-27T15:39:50.179Z" },
+]
+
+[[package]]
+name = "text-unidecode"
+version = "1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885, upload-time = "2019-08-30T21:36:45.405Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154, upload-time = "2019-08-30T21:37:03.543Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request introduces support for audio content in the Honeycomb application, adds CRUD (Create, Read, Update, Delete) API endpoints for various cell types, and improves the data model for better consistency and extensibility. The changes also include configuration updates for blob storage and dependency management.

**Key changes:**

### Audio Content Support
* Added a new `CellAudio` class to represent audio cells, storing metadata and binary audio data using ZODB blobs.
* Implemented form schema (`AudioCellSchema`) and view logic to handle audio uploads, metadata retrieval, and streaming. [[1]](diffhunk://#diff-5c11dfa988eeabde985de03b00a392f21b4163b85b175ea30a2fc83348c56cddR1-R9) [[2]](diffhunk://#diff-b1aa968ba3cc2c5cc6aef9a23f35cafbde3cd9d29089e488e77a2f32c9664a5dR73-R115) [[3]](diffhunk://#diff-b1aa968ba3cc2c5cc6aef9a23f35cafbde3cd9d29089e488e77a2f32c9664a5dR267-R441)
* Registered new views for audio metadata and streaming endpoints.

### API Endpoints for Cell CRUD Operations
* Added JSON API endpoints for creating, updating, and deleting nodes of types: audio, video, image, animation, text, and web content.
* Implemented metadata views for each cell type, returning relevant attributes in JSON format.

### Data Model Improvements
* Updated all cell and node classes to use `uuid.UUID` objects for IDs instead of strings, and improved name assignment logic to use slugs or UUID hex values for uniqueness. [[1]](diffhunk://#diff-dedf0f5fd49845243c5ab94da13f3bcad4c8700cb3cd5a9a17ff8d9c174a713dL17-R18) [[2]](diffhunk://#diff-dedf0f5fd49845243c5ab94da13f3bcad4c8700cb3cd5a9a17ff8d9c174a713dL84-R98) [[3]](diffhunk://#diff-dedf0f5fd49845243c5ab94da13f3bcad4c8700cb3cd5a9a17ff8d9c174a713dR230-L238)
* Refactored constructors of cell classes to ensure consistent initialization and parent/child relationships. [[1]](diffhunk://#diff-dedf0f5fd49845243c5ab94da13f3bcad4c8700cb3cd5a9a17ff8d9c174a713dL271-R290) [[2]](diffhunk://#diff-dedf0f5fd49845243c5ab94da13f3bcad4c8700cb3cd5a9a17ff8d9c174a713dL280-R299) [[3]](diffhunk://#diff-dedf0f5fd49845243c5ab94da13f3bcad4c8700cb3cd5a9a17ff8d9c174a713dL289-R308) [[4]](diffhunk://#diff-dedf0f5fd49845243c5ab94da13f3bcad4c8700cb3cd5a9a17ff8d9c174a713dL303-R322) [[5]](diffhunk://#diff-dedf0f5fd49845243c5ab94da13f3bcad4c8700cb3cd5a9a17ff8d9c174a713dL326-R345) [[6]](diffhunk://#diff-dedf0f5fd49845243c5ab94da13f3bcad4c8700cb3cd5a9a17ff8d9c174a713dL341-R360)

### Configuration and Dependencies
* Updated ZODB connection URIs in `development.ini` and `production.ini` to specify a blob storage directory for storing binary data. [[1]](diffhunk://#diff-28b1353404cfe6407a1e205f7e976b53023ceb27f0e86e499090b937316b8c84L20-R20) [[2]](diffhunk://#diff-da4aa12a0bb8aba792cc9f212d1f67bb1a6436fcbe6486b2e9ced6a5322c1ef8L15-R20)
* Added `python-slugify` to dependencies for generating slugified names from titles.

### Code Organization
* Exposed new form schemas by importing them in `honeycomb/forms/__init__.py`.
* Added necessary imports for new features in `honeycomb/views/default.py`.

These changes lay the groundwork for handling rich media content and provide a RESTful API for managing Honeycomb cell nodes.