### PR TITLE
Comunicacion de los videojuegos con la API (#15)

### DIFF
--- a/development.ini
+++ b/development.ini
@@ -25,7 +25,7 @@ retry.attempts = 3
 # '127.0.0.1' and '::1'.
 # debugtoolbar.hosts = 127.0.0.1 ::1
 
-auth.secret =
+auth.secret = development-only-insecure-secret
 
 # Enable only when the app is running behind a reverse proxy.
 honeycomb.use_proxy_headers = true

--- a/development.ini
+++ b/development.ini
@@ -30,6 +30,10 @@ auth.secret = development-only-insecure-secret
 # Enable only when the app is running behind a reverse proxy.
 honeycomb.use_proxy_headers = true
 
+# Dominios del Fediverso a los que nunca se les registra una app OAuth ni se
+# les redirige, separados por espacios. Vacio = nada bloqueado por default.
+fediverse.denylist =
+
 [pshell]
 setup = honeycomb.pshell.setup
 

--- a/development.ini
+++ b/development.ini
@@ -25,7 +25,11 @@ retry.attempts = 3
 # '127.0.0.1' and '::1'.
 # debugtoolbar.hosts = 127.0.0.1 ::1
 
-auth.secret = development-only-insecure-secret
+# Este valor debe establecerlo quien administre la instancia de la plataforma,
+# por lo que deberia quedarse vacio aqui. Sin un valor real, el servidor no
+# arranca (assert explicito) en vez de firmar cookies con un secreto conocido.
+# Para desarrollo local, pon el tuyo aqui o exportalo por variable de entorno.
+auth.secret =
 
 # Enable only when the app is running behind a reverse proxy.
 honeycomb.use_proxy_headers = true
@@ -33,6 +37,30 @@ honeycomb.use_proxy_headers = true
 # Dominios del Fediverso a los que nunca se les registra una app OAuth ni se
 # les redirige, separados por espacios. Vacio = nada bloqueado por default.
 fediverse.denylist =
+
+# Limites configurables por quien administra la instancia. Vacio/0 = sin limite.
+honeycomb.max_game_payload_keys =
+fediverse.registration_rate_window_seconds =
+fediverse.registration_rate_max_per_domain =
+fediverse.registration_rate_max_global =
+
+# Clave Fernet para cifrar en reposo el access_token OAuth del Fediverso (hace
+# falta para publicar logros a nombre del usuario). Vacio = el token nunca se
+# guarda y publicar queda deshabilitado. Generar con:
+#   uv run python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+honeycomb.token_encryption_key =
+
+# Cuentas locales (usuario + contrasena), alternativa a entrar por el
+# Fediverso, con registro abierto. Vacio = deshabilitadas: las activa quien
+# administra la instancia. Sin correo en el proyecto no hay verificacion de
+# cuenta ni recuperacion de contrasena -- quien la pierde pierde esa
+# credencial (puede seguir entrando por cualquier otra que tenga vinculada).
+honeycomb.local_accounts =
+honeycomb.min_password_length =
+honeycomb.login_rate_window_seconds =
+honeycomb.login_rate_max_per_user =
+honeycomb.login_rate_max_global =
+honeycomb.registration_rate_max_global =
 
 [pshell]
 setup = honeycomb.pshell.setup

--- a/docs/comunicacion-videojuegos-api.md
+++ b/docs/comunicacion-videojuegos-api.md
@@ -1,0 +1,144 @@
+# Comunicación de los videojuegos con la API
+
+Referencia: issue #15 "Comunicación de los videojuegos con la API".
+
+Este documento describe el contrato homologado con el que cualquier videojuego de la plataforma se comunica con el backend de Honeycomb. Es el mismo contrato para todos los juegos: mismos endpoints, mismo formato de respuesta, mismo SDK.
+
+## Resumen
+
+| Necesidad | Endpoint | Método | Acceso |
+|---|---|---|---|
+| Datos del usuario | `/api/v1/me` | GET | solo lectura |
+| Interacciones previas con un contenido | `/api/v1/games/{nodeid}/data` | GET | solo lectura (campo `interactions`) |
+| Estadísticas del usuario en ese contenido | `/api/v1/games/{nodeid}/data` | GET/POST | lectura/escritura (campo `stats`) |
+| Preferencias del usuario en ese contenido | `/api/v1/games/{nodeid}/data` | GET/POST | lectura/escritura (campo `preferences`) |
+
+`nodeid` es el `uuid` del nodo/celda que representa al videojuego dentro de un Honeycomb (el mismo id que ya expone `GET /api/v1/node/{node_id}`).
+
+Todos los endpoints requieren sesión autenticada (cookie de sesión de Honeycomb). Sin sesión, responden `401`.
+
+## Endpoints
+
+### GET /api/v1/me
+
+Información de solo lectura del usuario autenticado.
+
+Respuesta 200:
+```json
+{
+  "userid": "convida@unam.social",
+  "displayname": "Convida UNAM",
+  "username": "convida@unam.social",
+  "icon": "/static/bumblebee-512x512.png",
+  "background": "/static/honeycomb.png"
+}
+```
+
+Sin sesión: `401 {"error": "Unauthorized"}`.
+
+Un videojuego nunca puede modificar estos datos: no existe verbo de escritura para este recurso.
+
+### GET /api/v1/games/{nodeid}/data
+
+Devuelve el registro homologado del usuario autenticado para ese contenido. Si el usuario nunca ha interactuado con el nodo, devuelve valores por defecto (no crea nada).
+
+Respuesta 200:
+```json
+{
+  "userid": "convida@unam.social",
+  "nodeid": "juego-de-serpiente",
+  "interactions": 3,
+  "stats": {"highscore": 950, "level": 4},
+  "preferences": {"difficulty": "hard"},
+  "badges": [],
+  "first_seen": "2026-07-10T18:03:11.482+00:00",
+  "last_seen": "2026-07-17T20:11:02.009+00:00"
+}
+```
+
+- `interactions`: solo lectura. Cuenta cuántas veces el usuario ha hecho POST a este endpoint para este nodo. El servidor lo calcula; el cliente no puede fijarlo.
+- `stats`: lectura/escritura libre para el juego (puntajes, niveles, lo que necesite).
+- `preferences`: lectura/escritura libre (p. ej. dificultad). Versión mínima: se guarda igual que `stats`, sin validación de esquema todavía. Pensado para ligarse más adelante al sistema de rutas de interacción (`BeePath`); eso queda fuera de este alcance.
+- `badges`: reservado para logros; hoy siempre vacío, no hay endpoint para otorgarlos todavía.
+
+Sin sesión: `401`.
+
+### POST /api/v1/games/{nodeid}/data
+
+Guarda `stats` y/o `preferences` del usuario autenticado para ese nodo, y cuenta una interacción más.
+
+Body:
+```json
+{
+  "stats": {"highscore": 950},
+  "preferences": {"difficulty": "hard"},
+  "replace": false
+}
+```
+
+Todos los campos son opcionales. `stats`/`preferences`, si vienen, deben ser objetos JSON (no listas ni escalares).
+
+- Por defecto (`replace` ausente o `false`) el servidor fusiona: las claves nuevas se agregan o sobrescriben, las claves existentes que no se mencionan se conservan.
+- Con `"replace": true`, `stats`/`preferences` se reemplazan por completo con lo enviado (aplica a ambos campos juntos).
+- El servidor incrementa `interactions` en 1 en cada POST exitoso, sin importar qué mande el cliente. Si el body incluye `"interactions": 999` o cualquier otro campo no reconocido, se ignora.
+- `userid` y `nodeid` los determina el servidor (sesión + URL), nunca el body: un usuario no puede leer ni escribir datos de otro usuario.
+
+Respuesta 200: el registro completo actualizado (mismo formato que el GET).
+
+Errores:
+- `401` sin sesión.
+- `400` si el body no es JSON válido, o si `stats`/`preferences` no son objetos.
+
+No requiere CSRF token (`require_csrf=False`): es una API JSON same-origin protegida por cookie de sesión más el gate de autenticación, no un formulario HTML.
+
+### Endpoints previos (compatibilidad)
+
+`GET /api/v1/drones/{userid}` y `GET /api/v1/userid` seguían de un trabajo exploratorio previo en esta misma rama y se dejan intactos por compatibilidad, pero **el contrato homologado a usar en juegos nuevos es `/api/v1/me`**.
+
+## Seguridad
+
+- Autenticación obligatoria: todos los endpoints de esta sección devuelven `401` sin sesión válida.
+- Los datos de juego se leen/escriben siempre con el `userid` de la sesión, nunca con un `userid` de la URL o del body: no hay forma de leer o modificar datos de otro usuario (sin IDOR).
+- `interactions` y `badges` los controla exclusivamente el servidor.
+- `cors_origins=('*',)` se mantiene igual que en los endpoints existentes, asumiendo que los juegos se sirven desde el mismo origen (`/static/...`). Si algún juego se sirve desde otro dominio, hay que cambiar esto por una lista explícita de orígenes y habilitar credenciales en CORS; no está resuelto en este alcance.
+- Límite de tamaño: `stats`/`preferences` aceptan como máximo 100 claves por objeto, para evitar abuso.
+
+## Persistencia
+
+Los registros (`GameData`) se guardan en ZODB, dentro de la raíz (`BeeHive.__game_data__`), indexados por `userid` y luego por `nodeid`. Sobreviven reinicios del servidor (a diferencia del borrador anterior, que usaba un diccionario en memoria).
+
+## SDK para videojuegos
+
+`honeycomb/static/sdk/honeycomb.js` es la forma homologada de hablar con estos endpoints: mismo código para todos los juegos.
+
+```html
+<script src="/static/sdk/honeycomb.js"></script>
+<script>
+  Honeycomb.connect().then(function (hc) {
+    console.log(hc.user.displayname);
+
+    hc.load('juego-de-serpiente').then(function (data) {
+      console.log('highscore previo:', data.stats.highscore);
+    });
+
+    hc.save('juego-de-serpiente', { stats: { highscore: 950 } });
+  });
+</script>
+```
+
+- `Honeycomb.connect(nodeId?)`: llama a `/me`, devuelve una sesión con `.user`. Si no se pasa `nodeId`, intenta detectarlo de `?nodeid=` en la URL del juego o de `data-node-id` en su propio `<script>` tag.
+- `hc.load(nodeId?)`: GET de `/games/{nodeid}/data`. Usa el `nodeId` de conexión si no se pasa uno explícito.
+- `hc.save(nodeId?, data)`: POST a `/games/{nodeid}/data`. También acepta `hc.save(data)` usando el `nodeId` de conexión.
+
+Pendiente (fuera de este alcance): la plataforma todavía no inyecta automáticamente `?nodeid=` en la URL de cada juego embebido; por ahora el `nodeId` debe pasarse explícitamente a `connect`/`load`/`save`, o el juego debe construirse conociendo su propio nodeid.
+
+## Nota sobre las pruebas
+
+`tests/test_api_games.py` usa el fixture `testapp` (ver `tests/conftest.py`). Ese fixture pasa `tm.active: True` en el entorno de cada request, lo cual hace que `pyramid_tm` no gestione la transacción de esa request; quien la cierra es el callback de cierre de conexión de `pyramid_zodbconn`, que siempre hace `abort()`. Consecuencia: cada request HTTP dentro de un test corre sobre ZODB en un estado vacío, y ninguna escritura sobrevive de un request al siguiente, ni dentro del mismo test. Por eso las pruebas HTTP en `test_api_games.py` solo verifican lo que un único request/response puede demostrar (autenticación, forma de la respuesta, que un POST cuenta como 1a interacción, validación de payload). El comportamiento que depende de varias llamadas (fusión de `stats` entre POSTs sucesivos, conteo acumulado de `interactions`) está cubierto en `tests/test_models.py`, probando `GameData`/`BeeHive.get_game_data` directamente sin pasar por HTTP.
+
+## Pendiente / fuera de alcance
+
+- Preferencias ligadas al sistema de rutas de interacción (`BeePath`): quedó como versión mínima (campo libre `preferences`), sin modelar `sequence`/`required`/`granted` todavía.
+- Otorgar `badges` desde algún endpoint (hoy el campo existe pero siempre vacío).
+- Inyección automática del `nodeid` del juego embebido desde la plataforma.
+- Integrar el SDK en un juego real de ejemplo (p. ej. Serpiente).

--- a/docs/comunicacion-videojuegos-api.md
+++ b/docs/comunicacion-videojuegos-api.md
@@ -14,6 +14,9 @@ Este es el primero de tres hilos de trabajo relacionados: (A, este documento) co
 | Interacciones previas con un contenido | `/api/v1/sipping/{nodeid}` | GET | solo lectura (campo `interactions`) |
 | Estadísticas del usuario en ese contenido | `/api/v1/sipping/{nodeid}` | GET/POST | lectura/escritura (campo `stats`) |
 | Preferencias del usuario en ese contenido | `/api/v1/sipping/{nodeid}` | GET/POST | lectura/escritura (campo `preferences`) |
+| Otorgar un logro (lo decide el juego, lo controla el servidor) | `/api/v1/sipping/{nodeid}/badges` | POST | escritura |
+| Logros del usuario en cualquier nodo | `/api/v1/achievements` | GET | solo lectura |
+| Publicar un logro al Fediverso del usuario | `/api/v1/share` | POST | escritura, opt-in explícito |
 
 Nombre de ruta alineado al contrato ya documentado en la wiki del proyecto ([convidauam/wikiabeja](https://github.com/convidauam/wikiabeja), `componentes/API.md`): `sipping`, no `games`.
 
@@ -30,13 +33,19 @@ Información de solo lectura del usuario autenticado.
 Respuesta 200:
 ```json
 {
-  "userid": "convida@unam.social",
+  "userid": "https://unam.social/users/convida",
   "displayname": "Convida UNAM",
   "username": "convida@unam.social",
   "icon": "/static/bumblebee-512x512.png",
-  "background": "/static/honeycomb.png"
+  "background": "/static/honeycomb.png",
+  "identities": [{"kind": "fediverse", "value": "https://unam.social/users/convida"}],
+  "can_share": true
 }
 ```
+
+- `userid` **no** es el handle: es el identificador canónico de la cuenta (URL del actor de ActivityPub si nació en el Fediverso, o un id opaco `local:<uuid>` si nació como cuenta local). Ver `docs/identidad-activitypub.md` para el modelo completo de identidad.
+- `identities`: credenciales vinculadas a esta cuenta (puede tener una de Fediverso, una de usuario/contraseña, o ambas si se vincularon desde `/cuenta`).
+- `can_share`: si hay lo necesario (identidad del Fediverso + token de publicación guardado) para que `POST /api/v1/share` funcione ahora mismo.
 
 Sin sesión: `401 {"error": "Unauthorized"}`.
 
@@ -63,9 +72,44 @@ Respuesta 200:
 - `interactions`: solo lectura. Cuenta cuántas veces el usuario ha hecho POST a este endpoint para este nodo. El servidor lo calcula; el cliente no puede fijarlo.
 - `stats`: lectura/escritura libre para el juego (puntajes, niveles, lo que necesite).
 - `preferences`: lectura/escritura libre (p. ej. dificultad). Versión mínima: se guarda igual que `stats`, sin validación de esquema todavía. Pensado para ligarse más adelante al sistema de rutas de interacción (`BeePath`); eso queda fuera de este alcance.
-- `badges`: reservado para logros; hoy siempre vacío, no hay endpoint para otorgarlos todavía.
+- `badges`: logros otorgados en este nodo (`[{id, title, icon, awarded_at}, ...]`). Solo lectura para el juego: se otorgan vía `POST /api/v1/sipping/{nodeid}/badges`, nunca desde este endpoint.
 
 Sin sesión: `401`.
+
+### POST /api/v1/sipping/{nodeid}/badges
+
+Otorga un logro al usuario autenticado para ese nodo. Es el juego quien decide *cuándo* otorgarlo (p. ej. al llegar a cierto puntaje), pero el otorgamiento en sí lo registra el servidor.
+
+Body:
+```json
+{"id": "high-score-100", "title": "Cien puntos", "icon": "🏆"}
+```
+
+`id` lo elige el juego (no es un UUID generado por el servidor: son los juegos los que saben qué logros existen). `title` es obligatorio; `icon` es opcional. Idempotente: otorgar el mismo `id` dos veces no lo duplica ni cambia su `awarded_at` original.
+
+Respuesta 200: el registro `sipping` completo, con el badge ya incluido en `badges` (mismo formato que `GET /api/v1/sipping/{nodeid}`).
+
+Errores: `401` sin sesión, `400` si falta `id`/`title` o `icon` no es texto.
+
+### GET /api/v1/achievements
+
+Todos los logros del usuario autenticado, en cualquier nodo (su vitrina).
+
+Respuesta 200:
+```json
+{"achievements": [{"id": "high-score-100", "title": "Cien puntos", "icon": "🏆", "awarded_at": "...", "nodeid": "juego-de-serpiente"}]}
+```
+
+### POST /api/v1/share
+
+Publica un logro ya otorgado como una nota en el Fediverso del usuario, vía ActivityPub C2S (su propio outbox) — nunca automático, siempre una acción explícita (del usuario o disparada por el juego con confirmación del usuario).
+
+Body:
+```json
+{"nodeid": "juego-de-serpiente", "badge_id": "high-score-100", "message": "opcional"}
+```
+
+Si `message` falta, se genera uno automático. Errores: `401` sin sesión, `400` si faltan campos o la cuenta no tiene forma de publicar (ver `can_share` en `/api/v1/me` para saber de antemano si conviene ofrecer este botón), `404` si el usuario nunca tiene ese logro en ese nodo, `502` si la instancia del Fediverso rechaza la publicación.
 
 ### POST /api/v1/sipping/{nodeid}
 
@@ -107,7 +151,7 @@ Nota sobre `sipping`: la ruta ya estaba documentada en la wiki, pero el borrador
 - Los datos de juego se leen/escriben siempre con el `userid` de la sesión, nunca con un `userid` de la URL o del body: no hay forma de leer o modificar datos de otro usuario (sin IDOR).
 - `interactions` y `badges` los controla exclusivamente el servidor.
 - `cors_origins=('*',)` se mantiene igual que en los endpoints existentes, asumiendo que los juegos se sirven desde el mismo origen (`/static/...`). Si algún juego se sirve desde otro dominio, hay que cambiar esto por una lista explícita de orígenes y habilitar credenciales en CORS; no está resuelto en este alcance.
-- Límite de tamaño: `stats`/`preferences` aceptan como máximo 100 claves por objeto, para evitar abuso.
+- Límite de tamaño: `stats`/`preferences` aceptan como máximo `honeycomb.max_game_payload_keys` claves por objeto (configurable por quien administra la instancia; vacío/0 = sin límite, que es el valor de fábrica).
 
 ## Persistencia
 
@@ -132,9 +176,12 @@ Los registros (`GameData`) se guardan en ZODB, dentro de la raíz (`BeeHive.__ga
 </script>
 ```
 
-- `Honeycomb.connect(nodeId?)`: llama a `/me`, devuelve una sesión con `.user`. Si no se pasa `nodeId`, intenta detectarlo de `?nodeid=` en la URL del juego o de `data-node-id` en su propio `<script>` tag.
+- `Honeycomb.connect(nodeId?)`: llama a `/me`, devuelve una sesión con `.user` (incluye `identities`/`can_share`, ver arriba). Si no se pasa `nodeId`, intenta detectarlo de `?nodeid=` en la URL del juego o de `data-node-id` en su propio `<script>` tag.
 - `hc.load(nodeId?)`: GET de `/sipping/{nodeid}`. Usa el `nodeId` de conexión si no se pasa uno explícito.
 - `hc.save(nodeId?, data)`: POST a `/sipping/{nodeid}`. También acepta `hc.save(data)` usando el `nodeId` de conexión.
+- `hc.awardBadge(nodeId?, badge)`: POST a `/sipping/{nodeid}/badges`, otorga un logro.
+- `hc.achievements()`: GET de `/achievements`, todos los logros del usuario en cualquier nodo.
+- `hc.share(nodeId, badgeId, message?)`: POST a `/share`, publica un logro al Fediverso. Revisar `hc.user.can_share` antes de mostrar el botón.
 
 Pendiente (fuera de este alcance): la plataforma todavía no inyecta automáticamente `?nodeid=` en la URL de cada juego embebido; por ahora el `nodeId` debe pasarse explícitamente a `connect`/`load`/`save`, o el juego debe construirse conociendo su propio nodeid.
 
@@ -155,7 +202,9 @@ const { data } = await client.getSippingData({ nodeid: 'juego-de-serpiente' });
 await client.saveSippingData({ nodeid: 'juego-de-serpiente' }, { stats: { highscore: 950 } });
 ```
 
-`operationId` por endpoint: `listHoneycombs`, `getHoneycomb`, `getNode`, `getMe`, `getDrone`, `getUserId`, `getSippingData`, `saveSippingData`.
+`operationId` por endpoint: `listHoneycombs`, `getHoneycomb`, `getNode`, `getMe`, `getDrone`, `getUserId`, `getSippingData`, `saveSippingData`, `awardBadge`, `getAchievements`, `shareAchievement`.
+
+Nota: el login (Fediverso, usuario/contraseña, registro, vincular/desvincular credenciales) **no** está en este spec a propósito — son formularios HTML con redirección (`303`), no una API JSON pensada para clientes programáticos. Un juego nunca inicia sesión por sí mismo: el jugador ya llega autenticado por haber entrado a la plataforma en el navegador. Ver `docs/identidad-activitypub.md`.
 
 **Nota de implementación:** el spec se mantiene a mano en `honeycomb/openapi.py`, no se genera con `cornice-swagger`. Se probó `cornice-swagger` (única versión existente, 1.0.1 de 2021) y sí corre con cornice 6.1/Python 3.12, pero genera **Swagger 2.0**, y `openapi-client-axios` requiere **OpenAPI 3.x** explícitamente (sin conversión automática). Mantener el spec a mano también evita depender de un paquete sin mantenimiento desde 2021 y da control total sobre los ejemplos de respuesta (cornice-swagger, sin esquemas `colander` en cada recurso, solo documenta `"UNDOCUMENTED RESPONSE"`). Verificado end-to-end con `openapi-client-axios` real contra el servidor local: generación del cliente, 401 sin sesión, y el flujo completo de `sipping` (GET default → POST → interactions incrementado).
 
@@ -166,6 +215,5 @@ await client.saveSippingData({ nodeid: 'juego-de-serpiente' }, { stats: { highsc
 ## Pendiente / fuera de alcance
 
 - Preferencias ligadas al sistema de rutas de interacción (`BeePath`): quedó como versión mínima (campo libre `preferences`), sin modelar `sequence`/`required`/`granted` todavía.
-- Otorgar `badges` desde algún endpoint (hoy el campo existe pero siempre vacío).
 - Inyección automática del `nodeid` del juego embebido desde la plataforma.
 - Integrar el SDK en un juego real de ejemplo (p. ej. Serpiente).

--- a/docs/comunicacion-videojuegos-api.md
+++ b/docs/comunicacion-videojuegos-api.md
@@ -1,17 +1,21 @@
 # Comunicación de los videojuegos con la API
 
-Referencia: issue #15 "Comunicación de los videojuegos con la API".
+Referencia: issue #15 "Comunicación de los videojuegos con la API". Los nombres de endpoint aquí están alineados al contrato ya documentado en [convidauam/wikiabeja](https://github.com/convidauam/wikiabeja) (`componentes/API.md`).
 
 Este documento describe el contrato homologado con el que cualquier videojuego de la plataforma se comunica con el backend de Honeycomb. Es el mismo contrato para todos los juegos: mismos endpoints, mismo formato de respuesta, mismo SDK.
+
+Este es el primero de tres hilos de trabajo relacionados: (A, este documento) contrato de endpoints, (B) capa OpenAPI/Swagger para que los juegos generen su cliente automáticamente, (C) login de identidad vía ActivityPub. B y C se documentan por separado cuando se implementen.
 
 ## Resumen
 
 | Necesidad | Endpoint | Método | Acceso |
 |---|---|---|---|
 | Datos del usuario | `/api/v1/me` | GET | solo lectura |
-| Interacciones previas con un contenido | `/api/v1/games/{nodeid}/data` | GET | solo lectura (campo `interactions`) |
-| Estadísticas del usuario en ese contenido | `/api/v1/games/{nodeid}/data` | GET/POST | lectura/escritura (campo `stats`) |
-| Preferencias del usuario en ese contenido | `/api/v1/games/{nodeid}/data` | GET/POST | lectura/escritura (campo `preferences`) |
+| Interacciones previas con un contenido | `/api/v1/sipping/{nodeid}` | GET | solo lectura (campo `interactions`) |
+| Estadísticas del usuario en ese contenido | `/api/v1/sipping/{nodeid}` | GET/POST | lectura/escritura (campo `stats`) |
+| Preferencias del usuario en ese contenido | `/api/v1/sipping/{nodeid}` | GET/POST | lectura/escritura (campo `preferences`) |
+
+Nombre de ruta alineado al contrato ya documentado en la wiki del proyecto ([convidauam/wikiabeja](https://github.com/convidauam/wikiabeja), `componentes/API.md`): `sipping`, no `games`.
 
 `nodeid` es el `uuid` del nodo/celda que representa al videojuego dentro de un Honeycomb (el mismo id que ya expone `GET /api/v1/node/{node_id}`).
 
@@ -38,7 +42,7 @@ Sin sesión: `401 {"error": "Unauthorized"}`.
 
 Un videojuego nunca puede modificar estos datos: no existe verbo de escritura para este recurso.
 
-### GET /api/v1/games/{nodeid}/data
+### GET /api/v1/sipping/{nodeid}
 
 Devuelve el registro homologado del usuario autenticado para ese contenido. Si el usuario nunca ha interactuado con el nodo, devuelve valores por defecto (no crea nada).
 
@@ -63,7 +67,7 @@ Respuesta 200:
 
 Sin sesión: `401`.
 
-### POST /api/v1/games/{nodeid}/data
+### POST /api/v1/sipping/{nodeid}
 
 Guarda `stats` y/o `preferences` del usuario autenticado para ese nodo, y cuenta una interacción más.
 
@@ -93,7 +97,9 @@ No requiere CSRF token (`require_csrf=False`): es una API JSON same-origin prote
 
 ### Endpoints previos (compatibilidad)
 
-`GET /api/v1/drones/{userid}` y `GET /api/v1/userid` seguían de un trabajo exploratorio previo en esta misma rama y se dejan intactos por compatibilidad, pero **el contrato homologado a usar en juegos nuevos es `/api/v1/me`**.
+`GET /api/v1/drones/{userid}` y `GET /api/v1/userid` ya estaban documentados en la wiki del proyecto y se dejan intactos; `/api/v1/me` se agrega como alias de conveniencia (mismo dato, sin tener que mandar el `userid` en la URL, sin riesgo de 403 por mismatch). Cualquiera de los dos sirve para el contrato homologado.
+
+Nota sobre `sipping`: la ruta ya estaba documentada en la wiki, pero el borrador original ahí descrito usaba un diccionario en memoria (se perdía al reiniciar el servidor). Esta implementación mantiene la misma ruta y el mismo propósito, pero con persistencia real en ZODB y separación explícita de solo lectura/lectura-escritura (ver más abajo).
 
 ## Seguridad
 
@@ -127,10 +133,31 @@ Los registros (`GameData`) se guardan en ZODB, dentro de la raíz (`BeeHive.__ga
 ```
 
 - `Honeycomb.connect(nodeId?)`: llama a `/me`, devuelve una sesión con `.user`. Si no se pasa `nodeId`, intenta detectarlo de `?nodeid=` en la URL del juego o de `data-node-id` en su propio `<script>` tag.
-- `hc.load(nodeId?)`: GET de `/games/{nodeid}/data`. Usa el `nodeId` de conexión si no se pasa uno explícito.
-- `hc.save(nodeId?, data)`: POST a `/games/{nodeid}/data`. También acepta `hc.save(data)` usando el `nodeId` de conexión.
+- `hc.load(nodeId?)`: GET de `/sipping/{nodeid}`. Usa el `nodeId` de conexión si no se pasa uno explícito.
+- `hc.save(nodeId?, data)`: POST a `/sipping/{nodeid}`. También acepta `hc.save(data)` usando el `nodeId` de conexión.
 
 Pendiente (fuera de este alcance): la plataforma todavía no inyecta automáticamente `?nodeid=` en la URL de cada juego embebido; por ahora el `nodeId` debe pasarse explícitamente a `connect`/`load`/`save`, o el juego debe construirse conociendo su propio nodeid.
+
+## Descubrimiento automático (OpenAPI + openapi-client-axios)
+
+Además del SDK, la API se describe en `GET /openapi/openapi.json` (OpenAPI 3.0.3), tal como lo documenta la wiki del proyecto en `Conexión_Cliente_Servidor.md`. Cualquier juego puede generar un cliente tipado con [openapi-client-axios](https://openapistack.co/docs/openapi-client-axios/intro/) y llamar por `operationId` en vez de armar URLs a mano:
+
+```js
+const OpenAPIClientAxios = require('openapi-client-axios').default;
+
+const api = new OpenAPIClientAxios({
+  definition: 'http://localhost:6543/openapi/openapi.json',
+  axiosConfigDefaults: { baseURL: 'http://localhost:6543', withCredentials: true },
+});
+const client = await api.init();
+
+const { data } = await client.getSippingData({ nodeid: 'juego-de-serpiente' });
+await client.saveSippingData({ nodeid: 'juego-de-serpiente' }, { stats: { highscore: 950 } });
+```
+
+`operationId` por endpoint: `listHoneycombs`, `getHoneycomb`, `getNode`, `getMe`, `getDrone`, `getUserId`, `getSippingData`, `saveSippingData`.
+
+**Nota de implementación:** el spec se mantiene a mano en `honeycomb/openapi.py`, no se genera con `cornice-swagger`. Se probó `cornice-swagger` (única versión existente, 1.0.1 de 2021) y sí corre con cornice 6.1/Python 3.12, pero genera **Swagger 2.0**, y `openapi-client-axios` requiere **OpenAPI 3.x** explícitamente (sin conversión automática). Mantener el spec a mano también evita depender de un paquete sin mantenimiento desde 2021 y da control total sobre los ejemplos de respuesta (cornice-swagger, sin esquemas `colander` en cada recurso, solo documenta `"UNDOCUMENTED RESPONSE"`). Verificado end-to-end con `openapi-client-axios` real contra el servidor local: generación del cliente, 401 sin sesión, y el flujo completo de `sipping` (GET default → POST → interactions incrementado).
 
 ## Nota sobre las pruebas
 

--- a/docs/identidad-activitypub.md
+++ b/docs/identidad-activitypub.md
@@ -1,0 +1,83 @@
+# Identidad de usuario vía ActivityPub (Fediverso)
+
+Segundo hilo relacionado con el issue #15: el usuario se autentica con la red social del Fediverso que elija ("Inicia sesión con el Fediverso"), en vez de un usuario fijo. Referencia de diseño: `docs/comunicacion-videojuegos-api.md` (hilo del contrato de endpoints) y la wiki [convidauam/wikiabeja](https://github.com/convidauam/wikiabeja).
+
+## Qué es y qué no es
+
+Esto es un **cliente OAuth 2.0 identity-only** contra la API estilo Mastodon que exponen la mayoría de los servidores del Fediverso. Honeycomb **no** implementa federación ActivityPub (no hay inbox/outbox, firmas HTTP, entrega asíncrona): solo resuelve una instancia, registra una app OAuth ahí, corre el flujo de `authorization_code`, y lee el perfil vía `verify_credentials`.
+
+En la práctica, "la red social que el usuario elija" significa **cualquier instancia compatible con la API de cliente de Mastodon** (Mastodon, Pleroma/Akkoma, GoToSocial, Pixelfed). Misskey/Firefish usan otro mecanismo (MiAuth) y no funcionan sin trabajo adicional; servidores que solo federan sin exponer esa API tampoco.
+
+Se eligió **entrada abierta**: cualquier dominio que el usuario escriba, no una lista blanca. Esto obliga a que el guard anti-SSRF sea estricto desde el día uno (ver abajo), ya que el backend hace peticiones salientes a un host arbitrario elegido por el usuario.
+
+## Flujo de login
+
+1. `GET /login` — renderiza el formulario (`login.jinja2`), pide el handle (`usuario@instancia`).
+2. `POST /api/v1/auth/login` (requiere CSRF, igual que el resto de la app):
+   - Parsea el handle → `(username, domain)`.
+   - Si el dominio nunca se ha visto: confirma con `/.well-known/nodeinfo` que hay un servidor real ahí (evita gastar un registro de app contra cualquier dominio).
+   - Intenta `/.well-known/oauth-authorization-server` (RFC 8414) para saber si la instancia soporta el scope `profile` (Mastodon 4.3+) y PKCE S256; si no, cae a `read:accounts` sin PKCE.
+   - Registra la app vía `POST /api/v1/apps` (o reusa la registrada antes para ese dominio, cacheada en ZODB) y genera un `state` de un solo uso.
+   - Redirige (303) a `https://<dominio>/oauth/authorize?...`.
+3. El usuario aprueba en **su propia instancia** (fuera de Honeycomb).
+4. `GET /api/v1/auth/callback`:
+   - Valida `state` (comparación timing-safe, un solo uso).
+   - Intercambia el `code` por un `access_token` en `POST /oauth/token`.
+   - Lee el perfil con `GET /api/v1/accounts/verify_credentials`.
+   - Mapea el perfil a `DroneUser`, lo guarda/actualiza en ZODB, y crea la sesión (`remember()`, misma cookie firmada de siempre).
+   - El `access_token` se descarta (no se persiste): login-only, no se guardan credenciales de terceros.
+
+`client_id`/`client_secret` de la instancia viajan también en la sesión (de un solo uso, se limpian en el callback) para que este flujo específico no dependa de releer la caché de ZODB en el siguiente request; la caché en ZODB solo acelera futuros logins al mismo dominio.
+
+## Mapeo a DroneUser
+
+| Campo DroneUser | Origen |
+|---|---|
+| `userid` | `account.uri` (Actor URI de ActivityPub) si está presente; si no, `"{dominio}#{account.id}"`. Nunca el handle: los usernames se pueden reciclar. |
+| `display_name` | `account.display_name` |
+| `username` | handle completo (`usuario@dominio`) |
+| `icon` | `account.avatar` |
+| `background` | `account.header` |
+
+`DroneUser` es ahora `Persistent` (antes era un objeto plano guardado en un dict hardcodeado en memoria) y vive en `BeeHive.__users__` (ZODB), indexado por `userid`. `BeeHive.__oauth_apps__` cachea `{client_id, client_secret}` por dominio.
+
+## Seguridad
+
+- **Guard anti-SSRF en toda llamada saliente** (nodeinfo, oauth metadata, registro de app, intercambio de token, verify_credentials): solo https, se resuelve el host y se rechaza si cualquier IP resuelta es privada/loopback/link-local/multicast/reservada, sin seguir redirects automáticos (se revalida cada salto a mano, hasta 3), con timeout. Ver `honeycomb/security/fediverse.py`.
+- `state` aleatorio de un solo uso, comparación timing-safe.
+- PKCE S256 cuando la instancia lo soporta.
+- `next` (a dónde redirigir tras login) se sanitiza: solo rutas relativas de un segmento, nunca `//host` (anti open-redirect).
+- El límite de confianza es la **instancia**, no el usuario individual: una instancia hostil podría afirmar cualquier username local suyo. Esto es inherente al modelo, no algo que este código pueda resolver.
+- El registro de app por dominio se cachea (no se re-registra en cada login al mismo dominio).
+- **Rate limit en `register_app`**: máximo 5 registros por dominio y 30 en total cada 10 minutos (en memoria de proceso, `honeycomb/security/fediverse.py:_RegistrationRateLimiter`). Evita que alguien haga un loop registrando apps contra muchos dominios distintos o reintentando el mismo.
+- **Denylist configurable**: `fediverse.denylist` en el `.ini` (espacio-separado). Un dominio en la lista nunca llega a registrar una app ni a redirigir — se corta justo después de parsear el handle, antes de cualquier llamada de red.
+
+## `redirect_uri` detrás del reverse proxy
+
+El `redirect_uri` que se registra con la instancia remota se construye con `request.application_url` (no `request.host_url`), porque en producción el backend queda montado bajo un prefijo (`/backend/`, según `reverse_proxy/conf.d/nginx.conf` de `convida_deployment`) que nginx quita antes de reenviar la petición al contenedor. `host_url` solo trae `scheme://host:puerto`; `application_url` además incluye ese prefijo (via `SCRIPT_NAME`, que `ForwardedHeadersMiddleware` en `honeycomb/__init__.py` arma a partir del header `X-Forwarded-Prefix` que sí manda ese nginx). Se verificó simulando el prefijo `/backend` en un request de prueba: tanto el `redirect_uri` del login como el `servers[0].url` de `/openapi/openapi.json` quedan correctos (`https://convida.cua.uam.mx/backend/...`). Depende de que `honeycomb.use_proxy_headers = true` esté activo en `production.ini` (ya lo está) y de que el proxy real siga mandando esos headers tal como los manda el `nginx.conf` revisado.
+
+## Verificado en vivo contra unam.social
+
+`convida@unam.social` es una instancia real: **Pleroma 2.9.1** (no Mastodon), cuenta "Proyecto Convida". Se verificó en vivo, sin mocks:
+
+- `discover_nodeinfo('unam.social')` → responde con software Pleroma 2.9.1 real, confirma que expone `mastodon_api`.
+- `discover_oauth_metadata('unam.social')` → `None` (Pleroma 2.9.1 no expone RFC 8414), cae correctamente a scope `read:accounts` sin PKCE.
+- `register_app` → registro real contra unam.social, devolvió `client_id`/`client_secret` reales.
+- La `authorize_url` construida devuelve `200` con el login real de unam.social.
+- El guard SSRF rechaza correctamente `localhost`.
+
+No se completó el último tramo (aprobar el login como `convida@unam.social` y terminar el intercambio de código) porque requiere credenciales reales de esa cuenta, que no están disponibles aquí; ese tramo sí está cubierto por pruebas automatizadas contra una instancia fake (ver abajo).
+
+## Pruebas
+
+- `tests/test_fediverse.py`: funciones puras de `honeycomb/security/fediverse.py` (parseo de handle, guard SSRF con `socket.getaddrinfo` mockeado, PKCE, elección de scope, mapeo a `DroneUser`).
+- `tests/test_auth_fediverse.py`: las vistas completas (`/login`, `/api/v1/auth/login`, `/api/v1/auth/callback`) contra una instancia fake monkeypatcheada — handle inválido, dominio sin nodeinfo, `state` faltante/incorrecto, `code` faltante, flujo completo exitoso, reuso de la app cacheada en el segundo login al mismo dominio.
+- El fixture `fediverse_stub` (en `tests/conftest.py`) además puentea `BeeHive.get_user`/`upsert_user`/`get_oauth_app`/`set_oauth_app` por fuera de ZODB, **solo para pruebas**: el fixture `testapp` aborta cada request en su propia transacción (ver nota en `docs/comunicacion-videojuegos-api.md`), así que sin este puente un usuario logueado en un request no existiría todavía para el siguiente. El código de producción usa ZODB en todo momento; esto se confirmó con la verificación en vivo de arriba.
+
+## Pendiente / fuera de alcance
+
+- Verificación inversa de WebFinger contra suplantación (queda como hardening de fase 2; el token OAuth de la instancia ya es el ancla de confianza del MVP).
+- Refresco de perfil (hoy se sobrescribe en cada login; no hay política de "cada cuánto" releer avatar/display_name).
+- Manejo especial de instancias que limitan o deniegan el registro de apps.
+- Cualquier forma de federación ActivityPub real (inbox/outbox, firmas HTTP, publicar/seguir en nombre del usuario).
+- Soporte para Misskey/Firefish (MiAuth) u otros protocolos de login no compatibles con la API de Mastodon.

--- a/docs/identidad-activitypub.md
+++ b/docs/identidad-activitypub.md
@@ -1,83 +1,129 @@
-# Identidad de usuario vía ActivityPub (Fediverso)
+# Identidad de usuario: Fediverso (ActivityPub) y cuentas locales
 
-Segundo hilo relacionado con el issue #15: el usuario se autentica con la red social del Fediverso que elija ("Inicia sesión con el Fediverso"), en vez de un usuario fijo. Referencia de diseño: `docs/comunicacion-videojuegos-api.md` (hilo del contrato de endpoints) y la wiki [convidauam/wikiabeja](https://github.com/convidauam/wikiabeja).
+Segundo hilo relacionado con el issue #15: el usuario se autentica con la red social del Fediverso que elija ("Inicia sesión con el Fediverso"), o con una cuenta local (usuario/contraseña) si no tiene una. Referencia de diseño: `docs/comunicacion-videojuegos-api.md` (hilo del contrato de endpoints) y la wiki [convidauam/wikiabeja](https://github.com/convidauam/wikiabeja).
 
 ## Qué es y qué no es
 
-Esto es un **cliente OAuth 2.0 identity-only** contra la API estilo Mastodon que exponen la mayoría de los servidores del Fediverso. Honeycomb **no** implementa federación ActivityPub (no hay inbox/outbox, firmas HTTP, entrega asíncrona): solo resuelve una instancia, registra una app OAuth ahí, corre el flujo de `authorization_code`, y lee el perfil vía `verify_credentials`.
+Un **cliente OAuth 2.0 identity-only** contra el Fediverso, más un login local opcional para quien no tiene cuenta ahí. El descubrimiento va primero por el estándar: **WebFinger resuelve el handle al Actor de ActivityPub**, y si el propio Actor declara sus endpoints OAuth (`endpoints.oauth*`, extensión de Mastodon/Pleroma), el registro de app, la autorización y el intercambio de token corren por esas rutas — es decir, **ActivityPub Client-to-Server (C2S)**, no la API específica de Mastodon. Cuando una instancia no las declara (p. ej. mastodon.social), se cae a las rutas conocidas de la API de Mastodon (`/api/v1/apps`, `/oauth/authorize`, `/oauth/token`), que Pleroma/Akkoma también implementan por compatibilidad.
 
-En la práctica, "la red social que el usuario elija" significa **cualquier instancia compatible con la API de cliente de Mastodon** (Mastodon, Pleroma/Akkoma, GoToSocial, Pixelfed). Misskey/Firefish usan otro mecanismo (MiAuth) y no funcionan sin trabajo adicional; servidores que solo federan sin exponer esa API tampoco.
+Honeycomb sí toca ActivityPub C2S más allá del login: publica notas en el outbox del usuario (`security/activitypub.py`) cuando decide compartir un logro — siempre opt-in, nunca automático. No implementa federación servidor-a-servidor (firmas HTTP, entrega asíncrona, `inbox` de recepción) ni lee el timeline del usuario.
+
+En la práctica, "la red social que el usuario elija" significa **cualquier instancia ActivityPub, con o sin las extensiones de Mastodon**: Mastodon, Pleroma/Akkoma, GoToSocial, Pixelfed. Misskey/Firefish usan otro mecanismo (MiAuth) y no funcionan sin trabajo adicional.
 
 Se eligió **entrada abierta**: cualquier dominio que el usuario escriba, no una lista blanca. Esto obliga a que el guard anti-SSRF sea estricto desde el día uno (ver abajo), ya que el backend hace peticiones salientes a un host arbitrario elegido por el usuario.
 
-## Flujo de login
+## Flujo de login por Fediverso
 
-1. `GET /login` — renderiza el formulario (`login.jinja2`), pide el handle (`usuario@instancia`).
+1. `GET /login` — renderiza el formulario (`login.jinja2`), pide el handle (`usuario@instancia`) o, alternativamente, usuario/contraseña de una cuenta local (ver más abajo).
 2. `POST /api/v1/auth/login` (requiere CSRF, igual que el resto de la app):
-   - Parsea el handle → `(username, domain)`.
-   - Si el dominio nunca se ha visto: confirma con `/.well-known/nodeinfo` que hay un servidor real ahí (evita gastar un registro de app contra cualquier dominio).
-   - Intenta `/.well-known/oauth-authorization-server` (RFC 8414) para saber si la instancia soporta el scope `profile` (Mastodon 4.3+) y PKCE S256; si no, cae a `read:accounts` sin PKCE.
-   - Registra la app vía `POST /api/v1/apps` (o reusa la registrada antes para ese dominio, cacheada en ZODB) y genera un `state` de un solo uso.
-   - Redirige (303) a `https://<dominio>/oauth/authorize?...`.
+   - Parsea el handle → `(username, domain)`; si el dominio está en `fediverse.denylist`, se corta aquí.
+   - **WebFinger** (`GET /.well-known/webfinger`, con `Accept: application/jrd+json` — algunas instancias, p. ej. Pleroma, dan 400 sin ese header) resuelve la URL del Actor.
+   - Si se resolvió, **`GET` al documento del Actor** (`Accept: application/activity+json`) y se leen sus `endpoints.oauth*`. Si no se resolvió, se confirma con `/.well-known/nodeinfo` que hay un servidor real ahí (evita gastar un registro de app contra cualquier dominio).
+   - `/.well-known/oauth-authorization-server` (RFC 8414) para saber si la instancia soporta PKCE S256; se pide scope de perfil (`profile`, o `read:accounts` si la instancia no anuncia soporte de `profile`) más `write:statuses` (necesario para poder publicar logros más adelante).
+   - Registra la app vía el endpoint de registro descubierto en el Actor, o `POST /api/v1/apps` si no lo declaró (o reusa la app ya registrada antes para ese dominio, cacheada en ZODB) y genera un `state` de un solo uso.
+   - Redirige (303) al endpoint de autorización descubierto (o `https://<dominio>/oauth/authorize` de fallback).
 3. El usuario aprueba en **su propia instancia** (fuera de Honeycomb).
 4. `GET /api/v1/auth/callback`:
    - Valida `state` (comparación timing-safe, un solo uso).
-   - Intercambia el `code` por un `access_token` en `POST /oauth/token`.
-   - Lee el perfil con `GET /api/v1/accounts/verify_credentials`.
-   - Mapea el perfil a `DroneUser`, lo guarda/actualiza en ZODB, y crea la sesión (`remember()`, misma cookie firmada de siempre).
-   - El `access_token` se descarta (no se persiste): login-only, no se guardan credenciales de terceros.
+   - Intercambia el `code` por un `access_token` en el endpoint de token descubierto (o el de fallback).
+   - El perfil sale del **documento del Actor** ya resuelto en el paso 2 (`actor_to_drone_user`); solo si no trajo un `id` usable se cae a `GET /api/v1/accounts/verify_credentials`.
+   - El `access_token` se **cifra (Fernet) y se guarda** en `DroneUser.access_token_encrypted` — hace falta conservarlo para poder publicar logros al outbox más adelante. Sin `honeycomb.token_encryption_key` configurada en el servidor, `encrypt_token` regresa `None`: el token nunca se persiste, ni en claro ni de ninguna otra forma, y publicar queda deshabilitado hasta que el administrador de la instancia provea una clave.
+   - Si ya había sesión iniciada (el usuario estaba **vinculando** un Fediverso a una cuenta existente, no iniciando sesión de cero), no se crea una cuenta nueva: se vincula la credencial a la cuenta actual y se funde el progreso si el Actor ya tenía uno propio (ver "Cuentas locales y vinculación").
+   - Si no, se busca o crea el `DroneUser`, se actualiza su perfil (`update_profile`, nunca reemplazando el objeto completo — así no se pierde un `password_hash` u otra credencial ya vinculada) y se crea la sesión (`remember()`).
 
 `client_id`/`client_secret` de la instancia viajan también en la sesión (de un solo uso, se limpian en el callback) para que este flujo específico no dependa de releer la caché de ZODB en el siguiente request; la caché en ZODB solo acelera futuros logins al mismo dominio.
+
+## Cuentas locales y vinculación
+
+No todo jugador tiene o quiere una cuenta del Fediverso. `honeycomb.local_accounts` (vacío = deshabilitado, es el valor de fábrica) habilita un segundo método de login: usuario + contraseña, con **registro abierto** (self-service, sin invitación).
+
+- Contraseñas hasheadas con `hashlib.scrypt` (stdlib, sin dependencias nuevas) — `security/passwords.py`. Formato autodescriptivo (`scrypt$n=...,r=...,p=...$salt$hash`) para poder subir el costo después sin invalidar los hashes ya guardados.
+- **Sin correo en el proyecto**: no hay verificación de cuenta ni recuperación de contraseña. Quien pierde su contraseña pierde esa credencial — puede seguir entrando por cualquier otra que tenga vinculada, pero no hay forma de recuperarla. Se avisa en la pantalla de registro, no solo aquí.
+- Login/registro dan siempre el **mismo mensaje genérico** ante "usuario no existe" y "contraseña incorrecta", para no confirmar por esa vía si un nombre está en uso.
+- Límite de intentos configurable (`honeycomb.login_rate_window_seconds`/`login_rate_max_per_user`/`login_rate_max_global`/`registration_rate_max_global`), mismo mecanismo de ventana deslizante que ya usaba el registro de apps OAuth (`security/ratelimit.py`, extraído de `security/fediverse.py` para reusarlo aquí).
+
+### El problema: dos métodos, ¿una cuenta o dos?
+
+El progreso (`GameData`, logros) se guarda por `userid`. Si alguien entra a veces por Fediverso y a veces con su cuenta local **sin vincularlas**, son dos cuentas distintas con dos historiales separados — se avisa explícitamente en `/login`, `/register` y `/cuenta` para que nadie lo suponga por accidente.
+
+Para quien sí quiere una sola cuenta con ambos métodos, `BeeHive.__identities__` mapea credenciales a un userid primario:
+
+- Credencial de Fediverso: clave `fediverse:<url del actor>`.
+- Credencial local: clave `password:<username>`.
+
+El userid primario de una cuenta nacida en el Fediverso sigue siendo la URL del Actor (cero migración: una cuenta ya guardada antes de este índice existir se sigue resolviendo igual, porque el login cae al userid natural cuando la credencial todavía no está en el índice). Una cuenta nacida local usa un userid opaco `local:<uuid>` — el nombre de usuario no es la llave de la base de datos, así se puede cambiar después sin romper el progreso.
+
+Vincular reutiliza el mismo baile OAuth del login: `POST /api/v1/auth/login` con sesión ya iniciada guarda a qué cuenta vincular (`oauth_link_to` en la sesión), y el callback, en vez de crear una sesión nueva, ata la credencial a la cuenta actual. Se niega a vincular un Actor que ya esté vinculado a **otra** cuenta.
+
+**Regla de fusión de progreso** (`BeeHive.merge_game_data`, por nodo, al vincular una credencial con progreso propio):
+
+| Campo | Regla |
+|---|---|
+| Nodo que solo tenía la cuenta que se vincula | Se copia a la cuenta primaria |
+| `badges` | Unión por `id`, conservando el `awarded_at` original de quien ya lo tenía |
+| `interactions` | Suma |
+| `first_seen` / `last_seen` | Mínimo / máximo |
+| `stats` y `preferences` | Gana la cuenta primaria (único campo genuinamente ambiguo: no hay forma correcta de sumarlos o elegir uno sin contexto del juego) |
+
+No se borra nada: el bucket original de la cuenta que se vincula se deja intacto (queda inalcanzable por la API, recuperable a mano si alguien se equivoca).
+
+Se puede desvincular una credencial desde `/cuenta` (`BeeHive.unlink_identity`), salvo la última: una cuenta nunca puede quedar sin ninguna forma de entrar.
 
 ## Mapeo a DroneUser
 
 | Campo DroneUser | Origen |
 |---|---|
-| `userid` | `account.uri` (Actor URI de ActivityPub) si está presente; si no, `"{dominio}#{account.id}"`. Nunca el handle: los usernames se pueden reciclar. |
-| `display_name` | `account.display_name` |
-| `username` | handle completo (`usuario@dominio`) |
-| `icon` | `account.avatar` |
-| `background` | `account.header` |
+| `userid` | Fediverso: `id` del Actor (URL), o `"{dominio}#{account.id}"` de `verify_credentials` si el Actor no trajo uno usable. Local: `local:<uuid>`. Nunca el handle: los usernames se pueden reciclar. |
+| `display_name` | `actor.name` (o `account.display_name` en el fallback) |
+| `username` | Fediverso: handle completo (`usuario@dominio`). Local: el nombre elegido al registrarse. |
+| `icon` / `background` | `actor.icon.url` / `actor.image.url` (defensivo: pueden venir como objeto, arreglo o `null`) |
+| `actor_url`, `inbox`, `outbox` | Del documento del Actor; necesarios para C2S (publicar logros) |
+| `access_token_encrypted` | Token OAuth cifrado (Fernet); `None` sin `honeycomb.token_encryption_key` configurada |
+| `password_hash` | Hash scrypt de la cuenta local; `None` si esta cuenta nunca vinculó una contraseña |
 
-`DroneUser` es ahora `Persistent` (antes era un objeto plano guardado en un dict hardcodeado en memoria) y vive en `BeeHive.__users__` (ZODB), indexado por `userid`. `BeeHive.__oauth_apps__` cachea `{client_id, client_secret}` por dominio.
+`DroneUser` es `Persistent` y vive en `BeeHive.__users__` (ZODB), indexado por `userid`. `BeeHive.__oauth_apps__` cachea `{client_id, client_secret}` por dominio; `BeeHive.__identities__` mapea credenciales al userid primario (ver arriba).
 
 ## Seguridad
 
-- **Guard anti-SSRF en toda llamada saliente** (nodeinfo, oauth metadata, registro de app, intercambio de token, verify_credentials): solo https, se resuelve el host y se rechaza si cualquier IP resuelta es privada/loopback/link-local/multicast/reservada, sin seguir redirects automáticos (se revalida cada salto a mano, hasta 3), con timeout. Ver `honeycomb/security/fediverse.py`.
-- `state` aleatorio de un solo uso, comparación timing-safe.
-- PKCE S256 cuando la instancia lo soporta.
+- **Guard anti-SSRF en toda llamada saliente** (WebFinger, Actor, nodeinfo, oauth metadata, registro de app, intercambio de token, verify_credentials, publicar al outbox): solo https, se resuelve el host y se rechaza si cualquier IP resuelta es privada/loopback/link-local/multicast/reservada, sin seguir redirects automáticos (se revalida cada salto a mano, hasta 3), con timeout. Ver `honeycomb/security/fediverse.py`.
+- `state` aleatorio de un solo uso, comparación timing-safe. PKCE S256 cuando la instancia lo soporta.
 - `next` (a dónde redirigir tras login) se sanitiza: solo rutas relativas de un segmento, nunca `//host` (anti open-redirect).
-- El límite de confianza es la **instancia**, no el usuario individual: una instancia hostil podría afirmar cualquier username local suyo. Esto es inherente al modelo, no algo que este código pueda resolver.
-- El registro de app por dominio se cachea (no se re-registra en cada login al mismo dominio).
-- **Rate limit en `register_app`**: máximo 5 registros por dominio y 30 en total cada 10 minutos (en memoria de proceso, `honeycomb/security/fediverse.py:_RegistrationRateLimiter`). Evita que alguien haga un loop registrando apps contra muchos dominios distintos o reintentando el mismo.
+- El límite de confianza del login por Fediverso es la **instancia**, no el usuario individual: una instancia hostil podría afirmar cualquier username local suyo. Esto es inherente al modelo, no algo que este código pueda resolver. El login local traslada esa confianza a Honeycomb mismo: es la contrapartida de no depender de una instancia externa.
+- El registro de app por dominio se cachea (no se re-registra en cada login al mismo dominio). **Rate limit** en registro de apps y en login/registro local (`security/ratelimit.py`, en memoria de proceso — con varios workers cada uno lleva su propia cuenta).
 - **Denylist configurable**: `fediverse.denylist` en el `.ini` (espacio-separado). Un dominio en la lista nunca llega a registrar una app ni a redirigir — se corta justo después de parsear el handle, antes de cualquier llamada de red.
+- Ningún límite (payload de juego, rate limits, `min_password_length`) está hardcodeado: todos se leen de settings, vacío/0 = sin límite, lo activa quien administra la instancia. Mismo criterio que `auth.secret`, que debe quedar vacío en el `.ini` versionado — cada despliegue pone el suyo, o el servidor no arranca.
 
 ## `redirect_uri` detrás del reverse proxy
 
-El `redirect_uri` que se registra con la instancia remota se construye con `request.application_url` (no `request.host_url`), porque en producción el backend queda montado bajo un prefijo (`/backend/`, según `reverse_proxy/conf.d/nginx.conf` de `convida_deployment`) que nginx quita antes de reenviar la petición al contenedor. `host_url` solo trae `scheme://host:puerto`; `application_url` además incluye ese prefijo (via `SCRIPT_NAME`, que `ForwardedHeadersMiddleware` en `honeycomb/__init__.py` arma a partir del header `X-Forwarded-Prefix` que sí manda ese nginx). Se verificó simulando el prefijo `/backend` en un request de prueba: tanto el `redirect_uri` del login como el `servers[0].url` de `/openapi/openapi.json` quedan correctos (`https://convida.cua.uam.mx/backend/...`). Depende de que `honeycomb.use_proxy_headers = true` esté activo en `production.ini` (ya lo está) y de que el proxy real siga mandando esos headers tal como los manda el `nginx.conf` revisado.
+El `redirect_uri` que se registra con la instancia remota se construye con `request.application_url` (no `request.host_url`), porque en producción el backend queda montado bajo un prefijo (`/backend/`, según `reverse_proxy/conf.d/nginx.conf` de `convida_deployment`) que nginx quita antes de reenviar la petición al contenedor. `host_url` solo trae `scheme://host:puerto`; `application_url` además incluye ese prefijo (via `SCRIPT_NAME`, que `ForwardedHeadersMiddleware` en `honeycomb/__init__.py` arma a partir del header `X-Forwarded-Prefix` que sí manda ese nginx). Depende de que `honeycomb.use_proxy_headers = true` esté activo en `production.ini` (ya lo está) y de que el proxy real siga mandando esos headers tal como los manda el `nginx.conf` revisado.
 
-## Verificado en vivo contra unam.social
+## Verificado en vivo
 
-`convida@unam.social` es una instancia real: **Pleroma 2.9.1** (no Mastodon), cuenta "Proyecto Convida". Se verificó en vivo, sin mocks:
+Contra dos instancias reales, sin mocks, usando las funciones de producción de `honeycomb/security/fediverse.py`:
 
-- `discover_nodeinfo('unam.social')` → responde con software Pleroma 2.9.1 real, confirma que expone `mastodon_api`.
-- `discover_oauth_metadata('unam.social')` → `None` (Pleroma 2.9.1 no expone RFC 8414), cae correctamente a scope `read:accounts` sin PKCE.
-- `register_app` → registro real contra unam.social, devolvió `client_id`/`client_secret` reales.
-- La `authorize_url` construida devuelve `200` con el login real de unam.social.
-- El guard SSRF rechaza correctamente `localhost`.
+| Verificación | unam.social (Pleroma 2.9.1) | mastodon.social |
+|---|---|---|
+| WebFinger | 200 con el Actor — requiere `Accept: application/jrd+json`, sin ese header da 400 | 200, sin ese requisito |
+| `endpoints.oauth*` en el Actor | Declara `oauthRegistrationEndpoint`/`oauthAuthorizationEndpoint`/`oauthTokenEndpoint`: descubrimiento AP C2S completo | No los declara (solo `sharedInbox`): cae al fallback de rutas Mastodon |
+| Mapeo Actor → `DroneUser` | `icon`/`image` como objeto `{url: ...}`, mapeados correctamente | `icon` ausente (`None`), manejado sin error |
 
-No se completó el último tramo (aprobar el login como `convida@unam.social` y terminar el intercambio de código) porque requiere credenciales reales de esa cuenta, que no están disponibles aquí; ese tramo sí está cubierto por pruebas automatizadas contra una instancia fake (ver abajo).
+No se completó el intercambio de código con una cuenta real (requiere aprobar el login en el navegador con una cuenta existente); ese tramo sí está cubierto por pruebas automatizadas contra una instancia fake.
 
 ## Pruebas
 
-- `tests/test_fediverse.py`: funciones puras de `honeycomb/security/fediverse.py` (parseo de handle, guard SSRF con `socket.getaddrinfo` mockeado, PKCE, elección de scope, mapeo a `DroneUser`).
-- `tests/test_auth_fediverse.py`: las vistas completas (`/login`, `/api/v1/auth/login`, `/api/v1/auth/callback`) contra una instancia fake monkeypatcheada — handle inválido, dominio sin nodeinfo, `state` faltante/incorrecto, `code` faltante, flujo completo exitoso, reuso de la app cacheada en el segundo login al mismo dominio.
-- El fixture `fediverse_stub` (en `tests/conftest.py`) además puentea `BeeHive.get_user`/`upsert_user`/`get_oauth_app`/`set_oauth_app` por fuera de ZODB, **solo para pruebas**: el fixture `testapp` aborta cada request en su propia transacción (ver nota en `docs/comunicacion-videojuegos-api.md`), así que sin este puente un usuario logueado en un request no existiría todavía para el siguiente. El código de producción usa ZODB en todo momento; esto se confirmó con la verificación en vivo de arriba.
+- `tests/test_fediverse.py`: funciones puras de `honeycomb/security/fediverse.py` (parseo de handle, WebFinger, Actor, endpoints declarados con fallback, guard SSRF, PKCE, elección de scope, mapeo a `DroneUser`, rate limiter).
+- `tests/test_passwords.py`, `tests/test_local_accounts.py`: hasheo/verificación de contraseñas, registro/login/vinculación/desvinculación a nivel de modelo (sin HTTP).
+- `tests/test_tokenstore.py`: cifrado/descifrado del `access_token`.
+- `tests/test_models.py`: `BeeHive.merge_game_data` (fusión de progreso al vincular) y el índice de identidades, directamente sobre el modelo.
+- `tests/test_auth_fediverse.py`, `tests/test_local_auth.py`: las vistas completas (`/login`, `/register`, `/cuenta`, `/api/v1/auth/*`) contra una instancia fake monkeypatcheada — handle inválido, dominio sin nodeinfo/actor, `state` faltante/incorrecto, flujo completo exitoso, reuso de la app cacheada, cuenta local duplicada, vincular Fediverso a una cuenta local con fusión de progreso, vincular un Actor ya vinculado a otra cuenta (rechazado).
+- Los fixtures `identity_bridge`/`game_data_bridge` (en `tests/conftest.py`) puentean `BeeHive.get_user`/`upsert_user`/`resolve_identity`/`link_identity`/`get_game_data`/`merge_game_data` por fuera de ZODB, **solo para pruebas**: el fixture `testapp` aborta cada request en su propia transacción (ver nota en `docs/comunicacion-videojuegos-api.md`), así que sin este puente una cuenta creada en un request no existiría todavía para el siguiente. El código de producción usa ZODB en todo momento; esto se confirmó con la verificación en vivo de arriba.
 
 ## Pendiente / fuera de alcance
 
-- Verificación inversa de WebFinger contra suplantación (queda como hardening de fase 2; el token OAuth de la instancia ya es el ancla de confianza del MVP).
-- Refresco de perfil (hoy se sobrescribe en cada login; no hay política de "cada cuánto" releer avatar/display_name).
+- Verificación inversa de WebFinger contra suplantación (el token OAuth de la instancia sigue siendo el ancla de confianza).
+- Refresco de perfil (hoy se actualiza en cada login; no hay política de "cada cuánto" releer avatar/display_name si el usuario no vuelve a entrar).
 - Manejo especial de instancias que limitan o deniegan el registro de apps.
-- Cualquier forma de federación ActivityPub real (inbox/outbox, firmas HTTP, publicar/seguir en nombre del usuario).
-- Soporte para Misskey/Firefish (MiAuth) u otros protocolos de login no compatibles con la API de Mastodon.
+- Federación servidor-a-servidor (firmas HTTP, entrega asíncrona, `inbox` de recepción), lectura del timeline del usuario.
+- Soporte para Misskey/Firefish (MiAuth) u otros protocolos de login no compatibles con WebFinger + Actor AS2.
+- Verificación de correo y recuperación de contraseña para cuentas locales (requeriría infraestructura de correo, que el proyecto no tiene).
+- Si una cuenta tiene más de una identidad de Fediverso vinculada, solo la última usada actualiza `actor_url`/`inbox`/`outbox`/`access_token_encrypted` (campos únicos en `DroneUser`, no una lista) — publicar logros usa siempre esa última.

--- a/honeycomb/models/beehive.py
+++ b/honeycomb/models/beehive.py
@@ -74,6 +74,8 @@ class BeeHive(PersistentMapping):
         self.__nodes__ = OOBTree()
         self.__edges__ = OOBTree()
         self.__game_data__ = OOBTree()
+        self.__users__ = OOBTree()
+        self.__oauth_apps__ = OOBTree()
 
     # datos de videojuegos (GameData): acceso homologado por usuario + nodo
     def get_game_data(self, userid, nodeid, create=False):
@@ -92,6 +94,31 @@ class BeeHive(PersistentMapping):
             record = GameData(userid, nodeid)
             user_bucket[nodeid] = record
         return record
+
+    # usuarios autenticados vía identidad del Fediverso, keyed por userid canónico
+    def get_user(self, userid):
+        if not hasattr(self, "__users__"):
+            self.__users__ = OOBTree()
+        return self.__users__.get(userid)
+
+    def upsert_user(self, drone_user):
+        """Guarda o actualiza un DroneUser ya construido, indexado por su userid."""
+        if not hasattr(self, "__users__"):
+            self.__users__ = OOBTree()
+        self.__users__[drone_user.userid] = drone_user
+        return drone_user
+
+    # credenciales OAuth registradas por instancia (dominio del Fediverso)
+    def get_oauth_app(self, domain):
+        if not hasattr(self, "__oauth_apps__"):
+            self.__oauth_apps__ = OOBTree()
+        return self.__oauth_apps__.get(domain)
+
+    def set_oauth_app(self, domain, client_id, client_secret):
+        if not hasattr(self, "__oauth_apps__"):
+            self.__oauth_apps__ = OOBTree()
+        self.__oauth_apps__[domain] = PersistentMapping({"client_id": client_id, "client_secret": client_secret})
+        return self.__oauth_apps__[domain]
 
     # gestión de nodos y aristas
     def add_node(self, node, recurse=False):

--- a/honeycomb/models/beehive.py
+++ b/honeycomb/models/beehive.py
@@ -4,7 +4,61 @@ from persistent.mapping import PersistentMapping
 from BTrees._OOBTree import OOBTree
 from persistent.list import PersistentList
 from .axes import CellBuilder
+import datetime
 import json, uuid
+
+
+def _utcnow_iso():
+    """Marca de tiempo UTC en formato ISO-8601 (serializable a JSON)."""
+    return datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+
+class GameData(Persistent):
+    """Datos persistentes de un videojuego para un usuario y un nodo.
+
+    interactions y badges: solo lectura para el juego (los controla el servidor).
+    stats y preferences: lectura/escritura.
+    """
+
+    def __init__(self, userid, nodeid):
+        self.userid = userid
+        self.nodeid = nodeid
+        self.interactions = 0
+        self.stats = PersistentMapping()
+        self.preferences = PersistentMapping()
+        self.badges = PersistentList()
+        now = _utcnow_iso()
+        self.first_seen = now
+        self.last_seen = now
+
+    def register_interaction(self):
+        """Suma una interacción (uso exclusivo del servidor) y refresca ``last_seen``."""
+        self.interactions += 1
+        self.last_seen = _utcnow_iso()
+
+    def merge_stats(self, stats, replace=False):
+        if replace:
+            self.stats.clear()
+        for key, value in stats.items():
+            self.stats[key] = value
+
+    def merge_preferences(self, preferences, replace=False):
+        if replace:
+            self.preferences.clear()
+        for key, value in preferences.items():
+            self.preferences[key] = value
+
+    def to_dict(self):
+        return {
+            "userid": self.userid,
+            "nodeid": self.nodeid,
+            "interactions": self.interactions,
+            "stats": dict(self.stats),
+            "preferences": dict(self.preferences),
+            "badges": list(self.badges),
+            "first_seen": self.first_seen,
+            "last_seen": self.last_seen,
+        }
 
 class BeeHive(PersistentMapping):
     """A container of Honeycombs. This represents the top-level hierarchy which gives entry to honeycombs. It should
@@ -19,6 +73,25 @@ class BeeHive(PersistentMapping):
         self.title = "BeeHive Root"
         self.__nodes__ = OOBTree()
         self.__edges__ = OOBTree()
+        self.__game_data__ = OOBTree()
+
+    # datos de videojuegos (GameData): acceso homologado por usuario + nodo
+    def get_game_data(self, userid, nodeid, create=False):
+        """Obtiene el GameData de (userid, nodeid). Si no existe y create=True, lo crea."""
+        if not hasattr(self, "__game_data__"):
+            # BeeHive persistido antes de añadir este atributo.
+            self.__game_data__ = OOBTree()
+        user_bucket = self.__game_data__.get(userid)
+        if user_bucket is None:
+            if not create:
+                return None
+            user_bucket = OOBTree()
+            self.__game_data__[userid] = user_bucket
+        record = user_bucket.get(nodeid)
+        if record is None and create:
+            record = GameData(userid, nodeid)
+            user_bucket[nodeid] = record
+        return record
 
     # gestión de nodos y aristas
     def add_node(self, node, recurse=False):

--- a/honeycomb/models/beehive.py
+++ b/honeycomb/models/beehive.py
@@ -48,6 +48,17 @@ class GameData(Persistent):
         for key, value in preferences.items():
             self.preferences[key] = value
 
+    def award_badge(self, badge_id, title, icon=None):
+        """Otorga un logro (controlado por el servidor). Idempotente: si el
+        usuario ya tiene este badge_id en este nodo, no lo duplica."""
+        for badge in self.badges:
+            if badge.id == badge_id:
+                return badge
+        badge = PollenBadge(badge_id, title, icon)
+        self.badges.append(badge)
+        self.last_seen = _utcnow_iso()
+        return badge
+
     def to_dict(self):
         return {
             "userid": self.userid,
@@ -55,7 +66,7 @@ class GameData(Persistent):
             "interactions": self.interactions,
             "stats": dict(self.stats),
             "preferences": dict(self.preferences),
-            "badges": list(self.badges),
+            "badges": [badge.to_dict() for badge in self.badges],
             "first_seen": self.first_seen,
             "last_seen": self.last_seen,
         }
@@ -76,6 +87,7 @@ class BeeHive(PersistentMapping):
         self.__game_data__ = OOBTree()
         self.__users__ = OOBTree()
         self.__oauth_apps__ = OOBTree()
+        self.__identities__ = OOBTree()
 
     # datos de videojuegos (GameData): acceso homologado por usuario + nodo
     def get_game_data(self, userid, nodeid, create=False):
@@ -94,6 +106,17 @@ class BeeHive(PersistentMapping):
             record = GameData(userid, nodeid)
             user_bucket[nodeid] = record
         return record
+
+    def iter_user_badges(self, userid):
+        """Genera (nodeid, PollenBadge) para cada logro del usuario, en cualquier nodo."""
+        if not hasattr(self, "__game_data__"):
+            return
+        user_bucket = self.__game_data__.get(userid)
+        if not user_bucket:
+            return
+        for nodeid, record in user_bucket.items():
+            for badge in record.badges:
+                yield nodeid, badge
 
     # usuarios autenticados vía identidad del Fediverso, keyed por userid canónico
     def get_user(self, userid):
@@ -119,6 +142,85 @@ class BeeHive(PersistentMapping):
             self.__oauth_apps__ = OOBTree()
         self.__oauth_apps__[domain] = PersistentMapping({"client_id": client_id, "client_secret": client_secret})
         return self.__oauth_apps__[domain]
+
+    # identidades: varias credenciales (Fediverso, contraseña local) pueden
+    # apuntar a la misma cuenta. Clave con namespace explicito: 'fediverse:<actor_url>'
+    # o 'password:<username>'. El userid primario de la cuenta no cambia por esto;
+    # este indice solo dice a que userid resolver cada credencial.
+    def resolve_identity(self, key):
+        if not hasattr(self, "__identities__"):
+            self.__identities__ = OOBTree()
+        return self.__identities__.get(key)
+
+    def link_identity(self, key, userid):
+        if not hasattr(self, "__identities__"):
+            self.__identities__ = OOBTree()
+        self.__identities__[key] = userid
+
+    def unlink_identity(self, key):
+        if not hasattr(self, "__identities__"):
+            self.__identities__ = OOBTree()
+        if key in self.__identities__:
+            del self.__identities__[key]
+
+    def iter_identities(self, userid):
+        if not hasattr(self, "__identities__"):
+            return
+        for key, linked_userid in self.__identities__.items():
+            if linked_userid == userid:
+                yield key
+
+    def merge_game_data(self, from_userid, into_userid):
+        """Fusiona el progreso de from_userid dentro de into_userid al vincular dos
+        credenciales de la misma persona. Regla por nodo: si into_userid no tiene
+        registro para ese nodo, se copia el de from_userid (con record.userid
+        reescrito); si ambos tienen registro, los badges se unen por id
+        conservando su awarded_at original, interactions se suma, first_seen/
+        last_seen toman el minimo/maximo, y stats/preferences los conserva
+        into_userid tal cual (son el unico campo ambiguo: no hay forma correcta
+        de sumarlos o elegir uno sin contexto del juego).
+
+        No borra nada: el bucket original de from_userid se deja intacto, solo
+        queda inalcanzable por la API. El llamador debe invocar esto una sola
+        vez por vinculacion nueva -- no es idempotente (llamarlo dos veces para
+        el mismo par sumaria interactions dos veces).
+        """
+        if from_userid == into_userid:
+            return
+        if not hasattr(self, "__game_data__"):
+            return
+        from_bucket = self.__game_data__.get(from_userid)
+        if not from_bucket:
+            return
+        into_bucket = self.__game_data__.get(into_userid)
+        if into_bucket is None:
+            into_bucket = OOBTree()
+            self.__game_data__[into_userid] = into_bucket
+
+        for nodeid, source in from_bucket.items():
+            target = into_bucket.get(nodeid)
+            if target is None:
+                copy = GameData(into_userid, nodeid)
+                copy.interactions = source.interactions
+                copy.stats.update(source.stats)
+                copy.preferences.update(source.preferences)
+                for badge in source.badges:
+                    clone = PollenBadge(badge.id, badge.title, badge.icon)
+                    clone.awarded_at = badge.awarded_at
+                    copy.badges.append(clone)
+                copy.first_seen = source.first_seen
+                copy.last_seen = source.last_seen
+                into_bucket[nodeid] = copy
+            else:
+                existing_ids = {badge.id for badge in target.badges}
+                for badge in source.badges:
+                    if badge.id not in existing_ids:
+                        clone = PollenBadge(badge.id, badge.title, badge.icon)
+                        clone.awarded_at = badge.awarded_at
+                        target.badges.append(clone)
+                target.interactions += source.interactions
+                target.first_seen = min(target.first_seen, source.first_seen)
+                target.last_seen = max(target.last_seen, source.last_seen)
 
     # gestión de nodos y aristas
     def add_node(self, node, recurse=False):
@@ -573,12 +675,19 @@ class CellWebContent(CellLeaf):
         return self.icon
 
 
-class PollenBadge:
-    def __init__(self, id: uuid.UUID, name: str, title: str, icon: str):
-        self.id = id
-        self.name = name
+class PollenBadge(Persistent):
+    """Un logro otorgado a un usuario para un nodo especifico. `id` lo elige el
+    juego (p.ej. 'high-score-100'), no es un UUID generado por el servidor:
+    son los juegos los que saben que logros existen."""
+
+    def __init__(self, badge_id, title, icon=None):
+        self.id = badge_id
         self.title = title
         self.icon = icon
+        self.awarded_at = _utcnow_iso()
+
+    def to_dict(self):
+        return {"id": self.id, "title": self.title, "icon": self.icon, "awarded_at": self.awarded_at}
 
 
 class BeePath:

--- a/honeycomb/models/users.py
+++ b/honeycomb/models/users.py
@@ -1,10 +1,23 @@
-class DroneUser:
+from persistent import Persistent
+
+
+class DroneUser(Persistent):
     def __init__(self, userid, display_name, username, icon=None, background=None):
         self.userid = userid
         self.display_name = display_name
         self.username = username
         self.icon = icon
         self.background = background
+
+    def update_profile(self, display_name=None, username=None, icon=None, background=None):
+        if display_name is not None:
+            self.display_name = display_name
+        if username is not None:
+            self.username = username
+        if icon is not None:
+            self.icon = icon
+        if background is not None:
+            self.background = background
 
     def get_stats(self, key=None):
         if hasattr(self, "__stats__"):

--- a/honeycomb/models/users.py
+++ b/honeycomb/models/users.py
@@ -2,14 +2,29 @@ from persistent import Persistent
 
 
 class DroneUser(Persistent):
-    def __init__(self, userid, display_name, username, icon=None, background=None):
+    def __init__(self, userid, display_name, username, icon=None, background=None,
+                 actor_url=None, inbox=None, outbox=None, access_token_encrypted=None,
+                 password_hash=None):
         self.userid = userid
         self.display_name = display_name
         self.username = username
         self.icon = icon
         self.background = background
+        # Identidad y buzones nativos de ActivityPub (AP C2S); necesarios para
+        # publicar/leer del Fediverso a nombre del usuario.
+        self.actor_url = actor_url
+        self.inbox = inbox
+        self.outbox = outbox
+        # Token de acceso OAuth, SIEMPRE cifrado (ver security/tokenstore.py). Sin
+        # una clave de cifrado configurada en el servidor, queda en None: el
+        # token nunca se persiste en claro.
+        self.access_token_encrypted = access_token_encrypted
+        # Hash de contrasena para el login local (ver security/passwords.py). None
+        # si esta cuenta nunca vinculo una contrasena (solo entra por Fediverso).
+        self.password_hash = password_hash
 
-    def update_profile(self, display_name=None, username=None, icon=None, background=None):
+    def update_profile(self, display_name=None, username=None, icon=None, background=None,
+                        actor_url=None, inbox=None, outbox=None):
         if display_name is not None:
             self.display_name = display_name
         if username is not None:
@@ -18,6 +33,22 @@ class DroneUser(Persistent):
             self.icon = icon
         if background is not None:
             self.background = background
+        if actor_url is not None:
+            self.actor_url = actor_url
+        if inbox is not None:
+            self.inbox = inbox
+        if outbox is not None:
+            self.outbox = outbox
+
+    def has_fediverse_identity(self):
+        """Si esta cuenta tiene un outbox del Fediverso vinculado (via login o
+        vinculacion). No implica que tenga un token utilizable -- ver can_share."""
+        return bool(self.outbox)
+
+    def can_share(self):
+        """Si hay suficiente (outbox + token cifrado) para publicar al Fediverso
+        a nombre de este usuario ahora mismo. Ver security/activitypub.py."""
+        return bool(self.outbox) and bool(self.access_token_encrypted)
 
     def get_stats(self, key=None):
         if hasattr(self, "__stats__"):

--- a/honeycomb/openapi.py
+++ b/honeycomb/openapi.py
@@ -17,6 +17,30 @@ USER_SCHEMA = {
     },
 }
 
+IDENTITY_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "kind": {"type": "string", "enum": ["fediverse", "password"], "description": "Tipo de credencial vinculada"},
+        "value": {"type": "string", "description": "URL del actor (fediverse) o nombre de usuario (password)"},
+    },
+}
+
+ME_SCHEMA = {
+    "allOf": [USER_SCHEMA, {
+        "type": "object",
+        "properties": {
+            "identities": {
+                "type": "array", "items": IDENTITY_SCHEMA,
+                "description": "Credenciales vinculadas a esta cuenta (Fediverso y/o usuario+contrasena)",
+            },
+            "can_share": {
+                "type": "boolean",
+                "description": "Si hay lo necesario (identidad del Fediverso + token) para publicar logros ahora mismo",
+            },
+        },
+    }],
+}
+
 SIPPING_SCHEMA = {
     "type": "object",
     "properties": {
@@ -29,6 +53,20 @@ SIPPING_SCHEMA = {
         "first_seen": {"type": "string", "format": "date-time"},
         "last_seen": {"type": "string", "format": "date-time"},
     },
+}
+
+BADGE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "id": {"type": "string"},
+        "title": {"type": "string"},
+        "icon": {"type": "string", "nullable": True},
+        "awarded_at": {"type": "string", "format": "date-time"},
+    },
+}
+
+ACHIEVEMENT_SCHEMA = {
+    "allOf": [BADGE_SCHEMA, {"type": "object", "properties": {"nodeid": {"type": "string"}}}],
 }
 
 ERROR_SCHEMA = {
@@ -92,9 +130,9 @@ def build_openapi_spec(base_url):
             "/api/v1/me": {
                 "get": {
                     "operationId": "getMe",
-                    "summary": "Datos de solo lectura del usuario autenticado",
+                    "summary": "Datos de solo lectura del usuario autenticado, incluyendo sus credenciales vinculadas",
                     "responses": {
-                        "200": {"description": "Perfil del usuario", "content": {"application/json": {"schema": USER_SCHEMA}}},
+                        "200": {"description": "Perfil del usuario", "content": {"application/json": {"schema": ME_SCHEMA}}},
                         "401": UNAUTHORIZED,
                     },
                 },
@@ -151,6 +189,71 @@ def build_openapi_spec(base_url):
                         "200": {"description": "Registro actualizado", "content": {"application/json": {"schema": SIPPING_SCHEMA}}},
                         "400": {"description": "JSON invalido o stats/preferences no son objetos", "content": {"application/json": {"schema": ERROR_SCHEMA}}},
                         "401": UNAUTHORIZED,
+                    },
+                },
+            },
+            "/api/v1/sipping/{nodeid}/badges": {
+                "post": {
+                    "operationId": "awardBadge",
+                    "summary": "Otorga un logro al usuario autenticado para un nodo (controlado por el juego)",
+                    "parameters": [{"name": "nodeid", "in": "path", "required": True, "schema": {"type": "string"}}],
+                    "requestBody": {
+                        "required": True,
+                        "content": {"application/json": {"schema": {
+                            "type": "object",
+                            "required": ["id", "title"],
+                            "properties": {
+                                "id": {"type": "string", "description": "Identificador del logro, elegido por el juego"},
+                                "title": {"type": "string"},
+                                "icon": {"type": "string", "nullable": True},
+                            },
+                        }}},
+                    },
+                    "responses": {
+                        "200": {"description": "Registro actualizado con el logro otorgado", "content": {"application/json": {"schema": SIPPING_SCHEMA}}},
+                        "400": {"description": "id/title faltantes o invalidos", "content": {"application/json": {"schema": ERROR_SCHEMA}}},
+                        "401": UNAUTHORIZED,
+                    },
+                },
+            },
+            "/api/v1/achievements": {
+                "get": {
+                    "operationId": "getAchievements",
+                    "summary": "Todos los logros del usuario autenticado, en cualquier nodo",
+                    "responses": {
+                        "200": {"description": "Lista de logros", "content": {"application/json": {"schema": {
+                            "type": "object",
+                            "properties": {"achievements": {"type": "array", "items": ACHIEVEMENT_SCHEMA}},
+                        }}}},
+                        "401": UNAUTHORIZED,
+                    },
+                },
+            },
+            "/api/v1/share": {
+                "post": {
+                    "operationId": "shareAchievement",
+                    "summary": "Publica un logro ya otorgado como una nota en el Fediverso del usuario (ActivityPub C2S)",
+                    "requestBody": {
+                        "required": True,
+                        "content": {"application/json": {"schema": {
+                            "type": "object",
+                            "required": ["nodeid", "badge_id"],
+                            "properties": {
+                                "nodeid": {"type": "string"},
+                                "badge_id": {"type": "string"},
+                                "message": {"type": "string", "description": "Mensaje personalizado; si falta, se genera uno automatico"},
+                            },
+                        }}},
+                    },
+                    "responses": {
+                        "200": {"description": "Publicado", "content": {"application/json": {"schema": {
+                            "type": "object",
+                            "properties": {"status": {"type": "string"}, "activity": {"type": "object"}},
+                        }}}},
+                        "400": {"description": "Datos invalidos o no hay token de publicacion disponible", "content": {"application/json": {"schema": ERROR_SCHEMA}}},
+                        "401": UNAUTHORIZED,
+                        "404": {"description": "El usuario no tiene ese logro en ese nodo", "content": {"application/json": {"schema": ERROR_SCHEMA}}},
+                        "502": {"description": "La instancia del Fediverso rechazo la publicacion", "content": {"application/json": {"schema": ERROR_SCHEMA}}},
                     },
                 },
             },

--- a/honeycomb/openapi.py
+++ b/honeycomb/openapi.py
@@ -1,0 +1,158 @@
+"""Documento OpenAPI 3.0 servido en /openapi/openapi.json.
+
+Se mantiene a mano en vez de generarse con cornice-swagger: cornice-swagger
+1.0.1 (ultima version, 2021) produce Swagger 2.0, y openapi-client-axios
+(la libreria documentada para el frontend/juegos) requiere OpenAPI 3.x
+explicitamente, sin conversion automatica.
+"""
+
+USER_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "userid": {"type": "string"},
+        "displayname": {"type": "string"},
+        "username": {"type": "string"},
+        "icon": {"type": "string", "nullable": True},
+        "background": {"type": "string", "nullable": True},
+    },
+}
+
+SIPPING_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "userid": {"type": "string"},
+        "nodeid": {"type": "string"},
+        "interactions": {"type": "integer", "readOnly": True},
+        "stats": {"type": "object"},
+        "preferences": {"type": "object"},
+        "badges": {"type": "array", "items": {"type": "object"}},
+        "first_seen": {"type": "string", "format": "date-time"},
+        "last_seen": {"type": "string", "format": "date-time"},
+    },
+}
+
+ERROR_SCHEMA = {
+    "type": "object",
+    "properties": {"error": {"type": "string"}},
+}
+
+UNAUTHORIZED = {
+    "description": "No hay sesion autenticada",
+    "content": {"application/json": {"schema": ERROR_SCHEMA, "example": {"error": "Unauthorized"}}},
+}
+
+
+def build_openapi_spec(base_url):
+    return {
+        "openapi": "3.0.3",
+        "info": {
+            "title": "Honeycomb API",
+            "version": "1.0.0",
+            "description": "API homologada de comunicacion entre los videojuegos de Convida y el backend Honeycomb.",
+        },
+        "servers": [{"url": base_url}],
+        "paths": {
+            "/api/v1/honeycombs": {
+                "get": {
+                    "operationId": "listHoneycombs",
+                    "summary": "Lista los honeycombs disponibles",
+                    "responses": {
+                        "200": {
+                            "description": "Lista de honeycombs",
+                            "content": {"application/json": {"schema": {
+                                "type": "object",
+                                "properties": {"honeycombs": {"type": "array", "items": {"type": "object"}}},
+                            }}},
+                        },
+                    },
+                },
+            },
+            "/api/v1/honeycombs/{name}": {
+                "get": {
+                    "operationId": "getHoneycomb",
+                    "summary": "Obtiene un honeycomb como grafo (nodo raiz, hijos y aristas)",
+                    "parameters": [{"name": "name", "in": "path", "required": True, "schema": {"type": "string"}}],
+                    "responses": {
+                        "200": {"description": "Grafo del honeycomb", "content": {"application/json": {"schema": {"type": "object"}}}},
+                        "404": {"description": "Honeycomb no encontrado", "content": {"application/json": {"schema": ERROR_SCHEMA}}},
+                    },
+                },
+            },
+            "/api/v1/node/{node_id}": {
+                "get": {
+                    "operationId": "getNode",
+                    "summary": "Obtiene los datos de un nodo por su id",
+                    "parameters": [{"name": "node_id", "in": "path", "required": True, "schema": {"type": "string"}}],
+                    "responses": {
+                        "200": {"description": "Datos del nodo", "content": {"application/json": {"schema": {"type": "object"}}}},
+                        "404": {"description": "Nodo no encontrado", "content": {"application/json": {"schema": ERROR_SCHEMA}}},
+                    },
+                },
+            },
+            "/api/v1/me": {
+                "get": {
+                    "operationId": "getMe",
+                    "summary": "Datos de solo lectura del usuario autenticado",
+                    "responses": {
+                        "200": {"description": "Perfil del usuario", "content": {"application/json": {"schema": USER_SCHEMA}}},
+                        "401": UNAUTHORIZED,
+                    },
+                },
+            },
+            "/api/v1/drones/{userid}": {
+                "get": {
+                    "operationId": "getDrone",
+                    "summary": "Datos del usuario autenticado (requiere que userid coincida con la sesion)",
+                    "parameters": [{"name": "userid", "in": "path", "required": True, "schema": {"type": "string"}}],
+                    "responses": {
+                        "200": {"description": "Perfil del usuario", "content": {"application/json": {"schema": USER_SCHEMA}}},
+                        "401": UNAUTHORIZED,
+                        "403": {"description": "userid no coincide con la sesion", "content": {"application/json": {"schema": ERROR_SCHEMA}}},
+                    },
+                },
+            },
+            "/api/v1/userid": {
+                "get": {
+                    "operationId": "getUserId",
+                    "summary": "userid del usuario autenticado",
+                    "responses": {
+                        "200": {"description": "userid", "content": {"application/json": {"schema": {
+                            "type": "object", "properties": {"userid": {"type": "string"}},
+                        }}}},
+                        "401": UNAUTHORIZED,
+                    },
+                },
+            },
+            "/api/v1/sipping/{nodeid}": {
+                "get": {
+                    "operationId": "getSippingData",
+                    "summary": "Datos homologados del videojuego para el usuario autenticado y un nodo",
+                    "parameters": [{"name": "nodeid", "in": "path", "required": True, "schema": {"type": "string"}}],
+                    "responses": {
+                        "200": {"description": "Registro de interaccion", "content": {"application/json": {"schema": SIPPING_SCHEMA}}},
+                        "401": UNAUTHORIZED,
+                    },
+                },
+                "post": {
+                    "operationId": "saveSippingData",
+                    "summary": "Guarda stats/preferences del usuario para un nodo; cuenta una interaccion mas",
+                    "parameters": [{"name": "nodeid", "in": "path", "required": True, "schema": {"type": "string"}}],
+                    "requestBody": {
+                        "content": {"application/json": {"schema": {
+                            "type": "object",
+                            "properties": {
+                                "stats": {"type": "object"},
+                                "preferences": {"type": "object"},
+                                "replace": {"type": "boolean", "default": False},
+                            },
+                        }}},
+                    },
+                    "responses": {
+                        "200": {"description": "Registro actualizado", "content": {"application/json": {"schema": SIPPING_SCHEMA}}},
+                        "400": {"description": "JSON invalido o stats/preferences no son objetos", "content": {"application/json": {"schema": ERROR_SCHEMA}}},
+                        "401": UNAUTHORIZED,
+                    },
+                },
+            },
+        },
+    }

--- a/honeycomb/security/__init__.py
+++ b/honeycomb/security/__init__.py
@@ -1,5 +1,6 @@
 from pyramid.csrf import CookieCSRFStoragePolicy
 from .policy import SecurityPolicy
+from . import fediverse, local_accounts
 
 def includeme(config):
     settings = config.get_settings()
@@ -8,3 +9,5 @@ def includeme(config):
     config.set_default_csrf_options(require_csrf=True)
 
     config.set_security_policy(SecurityPolicy(settings['auth.secret']))
+    fediverse.configure_registration_rate_limiter(settings)
+    local_accounts.configure_rate_limiters(settings)

--- a/honeycomb/security/activitypub.py
+++ b/honeycomb/security/activitypub.py
@@ -1,0 +1,78 @@
+"""Publicacion y lectura via ActivityPub C2S (cliente-servidor), sobre el
+outbox del propio usuario. No implementa federacion S2S (firmas HTTP, entrega
+a otros servidores): eso lo hace la instancia del usuario al recibir el POST,
+igual que si el usuario hubiera publicado desde su propio cliente.
+"""
+
+import requests
+
+from .fediverse import FediverseError, _safe_request
+
+AS2_CONTEXT = 'https://www.w3.org/ns/activitystreams'
+C2S_CONTENT_TYPE = 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+
+
+def publish_note(outbox_url, access_token, content, to_public=True):
+    """POST un objeto Note al outbox del usuario, autenticado con su propio
+    access_token (Bearer) -- asi es como Mastodon/Pleroma reconocen que el
+    dueno del outbox autorizo la publicacion. El servidor la envuelve en una
+    actividad Create y le asigna id; no inventamos IDs propios (el spec no
+    lo permite para actividades generadas por el servidor)."""
+    if not outbox_url:
+        raise FediverseError('El usuario no tiene un outbox de ActivityPub conocido')
+    if not access_token:
+        raise FediverseError('No hay un token de acceso disponible para publicar')
+    note = {
+        '@context': AS2_CONTEXT,
+        'type': 'Note',
+        'content': content,
+    }
+    if to_public:
+        note['to'] = ['https://www.w3.org/ns/activitystreams#Public']
+    try:
+        response = _safe_request(
+            'POST', outbox_url, json=note,
+            headers={
+                'Authorization': f'Bearer {access_token}',
+                'Content-Type': C2S_CONTENT_TYPE,
+                'Accept': C2S_CONTENT_TYPE,
+            },
+        )
+    except requests.RequestException as exc:
+        raise FediverseError('No se pudo publicar en el Fediverso') from exc
+    if response.status_code >= 400:
+        raise FediverseError(f'La instancia rechazo la publicacion (HTTP {response.status_code})')
+    try:
+        return response.json()
+    except ValueError:
+        return {}
+
+
+def read_outbox(outbox_url, access_token=None):
+    """GET el outbox del usuario. Si es una OrderedCollection resumen (sin
+    items directos), sigue la pagina `first`."""
+    if not outbox_url:
+        raise FediverseError('El usuario no tiene un outbox de ActivityPub conocido')
+    headers = {'Accept': C2S_CONTENT_TYPE}
+    if access_token:
+        headers['Authorization'] = f'Bearer {access_token}'
+
+    collection = _get_json_or_raise(outbox_url, headers, 'No se pudo leer el outbox')
+    if 'orderedItems' in collection or 'items' in collection:
+        return collection
+
+    first = collection.get('first')
+    first_url = first if isinstance(first, str) else (first or {}).get('id')
+    if not first_url:
+        return collection
+    return _get_json_or_raise(first_url, headers, 'No se pudo leer la pagina del outbox')
+
+
+def _get_json_or_raise(url, headers, error_message):
+    try:
+        response = _safe_request('GET', url, headers=headers)
+    except requests.RequestException as exc:
+        raise FediverseError(error_message) from exc
+    if response.status_code >= 400:
+        raise FediverseError(f'{error_message} (HTTP {response.status_code})')
+    return response.json()

--- a/honeycomb/security/fediverse.py
+++ b/honeycomb/security/fediverse.py
@@ -1,10 +1,13 @@
-"""Cliente OAuth2 identity-only contra instancias del Fediverso (API estilo Mastodon).
+"""Cliente OAuth2 identity-only contra instancias del Fediverso, via ActivityPub C2S.
 
-No implementa federacion ActivityPub (inbox/outbox, firmas HTTP): solo resuelve
-la instancia de un handle, registra una app OAuth por dominio, corre el flujo
-de authorization code, y lee el perfil via verify_credentials. Como el acceso
-es de entrada abierta (cualquier dominio que el usuario escriba), todas las
-llamadas salientes pasan por un guard anti-SSRF.
+El descubrimiento va primero por el estandar: WebFinger (RFC 7033) resuelve el
+handle al Actor de ActivityPub, y el propio documento del Actor puede declarar
+sus endpoints OAuth (extension de Mastodon/Pleroma: endpoints.oauth*). Cuando
+una instancia no los declara (p.ej. mastodon.social), se cae a las rutas
+conocidas de la API de Mastodon (/api/v1/apps, /oauth/authorize, /oauth/token).
+No implementa federacion completa (inbox/outbox de escritura, firmas HTTP) mas
+alla de leer el perfil. Como el acceso es de entrada abierta (cualquier dominio
+que el usuario escriba), todas las llamadas salientes pasan por un guard anti-SSRF.
 """
 
 import base64
@@ -13,64 +16,52 @@ import hmac
 import ipaddress
 import secrets
 import socket
-import threading
-import time
 import urllib.parse
 
 import requests
 
+from . import ratelimit
 from ..models.users import DroneUser
 
 REQUEST_TIMEOUT = (3.05, 8)
 MAX_REDIRECTS = 3
-SCOPE_MODERN = 'profile'
-SCOPE_FALLBACK = 'read:accounts'
+SCOPE_PROFILE_MODERN = 'profile'
+SCOPE_PROFILE_FALLBACK = 'read:accounts'
+SCOPE_PUBLISH = 'write:statuses'
+AS2_CONTENT_TYPES = (
+    'application/activity+json',
+    'application/ld+json; profile="https://www.w3.org/ns/activitystreams"',
+)
 
-REGISTRATION_RATE_WINDOW_SECONDS = 600
-REGISTRATION_RATE_MAX_PER_DOMAIN = 5
-REGISTRATION_RATE_MAX_GLOBAL = 30
+# Defaults usados solo si nadie llama a configure_registration_rate_limiter (p.ej.
+# scripts sueltos via pshell). La app real los reemplaza en el arranque leyendo
+# settings del .ini -- ver security/__init__.py:includeme.
+DEFAULT_REGISTRATION_RATE_WINDOW_SECONDS = 600
+DEFAULT_REGISTRATION_RATE_MAX_PER_DOMAIN = 5
+DEFAULT_REGISTRATION_RATE_MAX_GLOBAL = 30
 
 
 class FediverseError(Exception):
     """Error de usuario al resolver/hablar con una instancia del Fediverso."""
 
 
-class _RegistrationRateLimiter:
-    """Limita cuantas veces se puede llamar a register_app: por dominio y en total.
-
-    En memoria de proceso (un solo worker via waitress); si el registro de apps
-    empieza a fallar mucho o se despliega con varios workers, mover esto a un
-    almacen compartido (p.ej. la misma ZODB, o un cache externo).
-    """
-
-    def __init__(self, window_seconds, max_per_domain, max_global):
-        self.window_seconds = window_seconds
-        self.max_per_domain = max_per_domain
-        self.max_global = max_global
-        self._lock = threading.Lock()
-        self._by_domain = {}
-        self._global = []
-
-    def check_and_record(self, domain):
-        now = time.monotonic()
-        cutoff = now - self.window_seconds
-        with self._lock:
-            self._global = [t for t in self._global if t > cutoff]
-            if len(self._global) >= self.max_global:
-                raise FediverseError('Demasiados registros de apps en este momento, intenta mas tarde')
-
-            domain_attempts = [t for t in self._by_domain.get(domain, []) if t > cutoff]
-            if len(domain_attempts) >= self.max_per_domain:
-                raise FediverseError(f"Demasiados intentos de registro para '{domain}', intenta mas tarde")
-
-            domain_attempts.append(now)
-            self._by_domain[domain] = domain_attempts
-            self._global.append(now)
-
-
-_registration_rate_limiter = _RegistrationRateLimiter(
-    REGISTRATION_RATE_WINDOW_SECONDS, REGISTRATION_RATE_MAX_PER_DOMAIN, REGISTRATION_RATE_MAX_GLOBAL,
+_registration_rate_limiter = ratelimit.SlidingWindowLimiter(
+    DEFAULT_REGISTRATION_RATE_WINDOW_SECONDS,
+    DEFAULT_REGISTRATION_RATE_MAX_PER_DOMAIN,
+    DEFAULT_REGISTRATION_RATE_MAX_GLOBAL,
 )
+
+
+def configure_registration_rate_limiter(settings):
+    """Llamado una vez al arrancar la app (security/__init__.py:includeme) para que
+    el rate limiter de register_app refleje lo configurado en el .ini."""
+    global _registration_rate_limiter
+    window = ratelimit.positive_int_setting(
+        settings, 'fediverse.registration_rate_window_seconds', DEFAULT_REGISTRATION_RATE_WINDOW_SECONDS,
+    )
+    max_per_domain = ratelimit.limit_setting_or_none(settings, 'fediverse.registration_rate_max_per_domain')
+    max_global = ratelimit.limit_setting_or_none(settings, 'fediverse.registration_rate_max_global')
+    _registration_rate_limiter = ratelimit.SlidingWindowLimiter(window, max_per_domain, max_global)
 
 
 def _is_public_ip(ip_text):
@@ -129,6 +120,54 @@ def parse_handle(handle):
     return username, domain
 
 
+def discover_actor_url(username, domain):
+    """WebFinger (RFC 7033): handle -> URL del Actor de ActivityPub. Requiere Accept:
+    application/jrd+json (algunas instancias, p.ej. unam.social/Pleroma, dan 400 sin
+    ese header). None si falla; nunca bloquea el login por si solo."""
+    try:
+        response = _safe_request(
+            'GET', f'https://{domain}/.well-known/webfinger',
+            params={'resource': f'acct:{username}@{domain}'},
+            headers={'Accept': 'application/jrd+json'},
+        )
+        if response.status_code != 200:
+            return None
+        for link in response.json().get('links', []):
+            if link.get('rel') == 'self' and link.get('type') in AS2_CONTENT_TYPES:
+                href = link.get('href')
+                if href:
+                    return href
+        return None
+    except (FediverseError, ValueError, requests.RequestException):
+        return None
+
+
+def fetch_actor(actor_url):
+    """GET del documento del Actor (perfil nativo de ActivityPub). None si falla."""
+    try:
+        response = _safe_request('GET', actor_url, headers={'Accept': 'application/activity+json'})
+        if response.status_code != 200:
+            return None
+        return response.json()
+    except (FediverseError, ValueError, requests.RequestException):
+        return None
+
+
+def actor_oauth_endpoints(actor):
+    """Endpoints OAuth que el propio Actor declara (extension de Mastodon/Pleroma en
+    `endpoints`). Diccionario vacio si el Actor no los expone (p.ej. mastodon.social,
+    que solo declara sharedInbox) -- el llamador cae a las rutas conocidas."""
+    endpoints = (actor or {}).get('endpoints') or {}
+    result = {}
+    if endpoints.get('oauthRegistrationEndpoint'):
+        result['registration'] = endpoints['oauthRegistrationEndpoint']
+    if endpoints.get('oauthAuthorizationEndpoint'):
+        result['authorization'] = endpoints['oauthAuthorizationEndpoint']
+    if endpoints.get('oauthTokenEndpoint'):
+        result['token'] = endpoints['oauthTokenEndpoint']
+    return result
+
+
 def discover_nodeinfo(domain):
     """Best-effort: confirma que el dominio responde como servidor real. Nunca bloquea el login."""
     try:
@@ -162,8 +201,14 @@ def discover_oauth_metadata(domain):
 
 
 def choose_scope(oauth_metadata):
+    """Scope pedido al iniciar sesion: lectura de perfil + capacidad de publicar
+    (para compartir logros). scopes_supported suele faltar en instancias viejas
+    (p.ej. Pleroma no expone RFC 8414); en ese caso se pide igual, ya que
+    write:statuses/profile son estandar en cualquier instancia compatible con
+    la API de Mastodon."""
     supported = (oauth_metadata or {}).get('scopes_supported') or []
-    return SCOPE_MODERN if SCOPE_MODERN in supported else SCOPE_FALLBACK
+    profile_scope = SCOPE_PROFILE_MODERN if SCOPE_PROFILE_MODERN in supported else SCOPE_PROFILE_FALLBACK
+    return f'{profile_scope} {SCOPE_PUBLISH}'
 
 
 def supports_pkce(oauth_metadata):
@@ -171,10 +216,18 @@ def supports_pkce(oauth_metadata):
     return 'S256' in methods
 
 
-def register_app(domain, redirect_uri, scope, client_name='Honeycomb'):
-    _registration_rate_limiter.check_and_record(domain)
+def register_app(domain, redirect_uri, scope, client_name='Honeycomb', endpoint=None):
+    """endpoint: URL de registro descubierta en el Actor (AP C2S); si falta, cae a
+    la ruta de la API de Mastodon (/api/v1/apps), que Pleroma/Akkoma tambien implementan."""
+    url = endpoint or f'https://{domain}/api/v1/apps'
     try:
-        response = _safe_request('POST', f'https://{domain}/api/v1/apps', data={
+        _registration_rate_limiter.check_and_record(domain)
+    except ratelimit.RateLimitError as exc:
+        if exc.scope == 'global':
+            raise FediverseError('Demasiados registros de apps en este momento, intenta mas tarde') from exc
+        raise FediverseError(f"Demasiados intentos de registro para '{domain}', intenta mas tarde") from exc
+    try:
+        response = _safe_request('POST', url, data={
             'client_name': client_name,
             'redirect_uris': redirect_uri,
             'scopes': scope,
@@ -209,7 +262,10 @@ def states_match(expected, received):
     return hmac.compare_digest(expected, received)
 
 
-def build_authorize_url(domain, client_id, redirect_uri, state, scope, code_challenge=None):
+def build_authorize_url(domain, client_id, redirect_uri, state, scope, code_challenge=None, endpoint=None):
+    """endpoint: URL de autorizacion descubierta en el Actor (AP C2S); si falta, cae
+    a la ruta de la API de Mastodon (/oauth/authorize)."""
+    base = endpoint or f'https://{domain}/oauth/authorize'
     params = {
         'response_type': 'code',
         'client_id': client_id,
@@ -220,10 +276,13 @@ def build_authorize_url(domain, client_id, redirect_uri, state, scope, code_chal
     if code_challenge:
         params['code_challenge'] = code_challenge
         params['code_challenge_method'] = 'S256'
-    return f'https://{domain}/oauth/authorize?' + urllib.parse.urlencode(params)
+    return base + '?' + urllib.parse.urlencode(params)
 
 
-def exchange_code(domain, client_id, client_secret, redirect_uri, code, scope, code_verifier=None):
+def exchange_code(domain, client_id, client_secret, redirect_uri, code, scope, code_verifier=None, endpoint=None):
+    """endpoint: URL de intercambio de token descubierta en el Actor (AP C2S); si
+    falta, cae a la ruta de la API de Mastodon (/oauth/token)."""
+    url = endpoint or f'https://{domain}/oauth/token'
     data = {
         'grant_type': 'authorization_code',
         'client_id': client_id,
@@ -235,7 +294,7 @@ def exchange_code(domain, client_id, client_secret, redirect_uri, code, scope, c
     if code_verifier:
         data['code_verifier'] = code_verifier
     try:
-        response = _safe_request('POST', f'https://{domain}/oauth/token', data=data)
+        response = _safe_request('POST', url, data=data)
     except requests.RequestException as exc:
         raise FediverseError(f"No se pudo intercambiar el codigo con {domain}") from exc
     if response.status_code >= 400:
@@ -287,3 +346,19 @@ def account_to_drone_user(domain, account):
     icon = _image_url(account.get('avatar') or account.get('avatar_static') or account.get('icon'))
     background = _image_url(account.get('header') or account.get('header_static') or account.get('image'))
     return DroneUser(userid=userid, display_name=display_name, username=handle, icon=icon, background=background)
+
+
+def actor_to_drone_user(domain, actor):
+    """Mapea el documento del Actor (AS2) a DroneUser. Fuente primaria del perfil en
+    el flujo AP C2S; verify_credentials (account_to_drone_user) queda como respaldo
+    para instancias donde el Actor no trae `id` usable."""
+    userid = actor.get('id') or f"{domain}#{actor.get('preferredUsername', '')}"
+    username = actor.get('preferredUsername') or ''
+    handle = f'{username}@{domain}' if username else domain
+    display_name = actor.get('name') or username or handle
+    icon = _image_url(actor.get('icon'))
+    background = _image_url(actor.get('image'))
+    return DroneUser(
+        userid=userid, display_name=display_name, username=handle, icon=icon, background=background,
+        actor_url=actor.get('id'), inbox=actor.get('inbox'), outbox=actor.get('outbox'),
+    )

--- a/honeycomb/security/fediverse.py
+++ b/honeycomb/security/fediverse.py
@@ -1,0 +1,289 @@
+"""Cliente OAuth2 identity-only contra instancias del Fediverso (API estilo Mastodon).
+
+No implementa federacion ActivityPub (inbox/outbox, firmas HTTP): solo resuelve
+la instancia de un handle, registra una app OAuth por dominio, corre el flujo
+de authorization code, y lee el perfil via verify_credentials. Como el acceso
+es de entrada abierta (cualquier dominio que el usuario escriba), todas las
+llamadas salientes pasan por un guard anti-SSRF.
+"""
+
+import base64
+import hashlib
+import hmac
+import ipaddress
+import secrets
+import socket
+import threading
+import time
+import urllib.parse
+
+import requests
+
+from ..models.users import DroneUser
+
+REQUEST_TIMEOUT = (3.05, 8)
+MAX_REDIRECTS = 3
+SCOPE_MODERN = 'profile'
+SCOPE_FALLBACK = 'read:accounts'
+
+REGISTRATION_RATE_WINDOW_SECONDS = 600
+REGISTRATION_RATE_MAX_PER_DOMAIN = 5
+REGISTRATION_RATE_MAX_GLOBAL = 30
+
+
+class FediverseError(Exception):
+    """Error de usuario al resolver/hablar con una instancia del Fediverso."""
+
+
+class _RegistrationRateLimiter:
+    """Limita cuantas veces se puede llamar a register_app: por dominio y en total.
+
+    En memoria de proceso (un solo worker via waitress); si el registro de apps
+    empieza a fallar mucho o se despliega con varios workers, mover esto a un
+    almacen compartido (p.ej. la misma ZODB, o un cache externo).
+    """
+
+    def __init__(self, window_seconds, max_per_domain, max_global):
+        self.window_seconds = window_seconds
+        self.max_per_domain = max_per_domain
+        self.max_global = max_global
+        self._lock = threading.Lock()
+        self._by_domain = {}
+        self._global = []
+
+    def check_and_record(self, domain):
+        now = time.monotonic()
+        cutoff = now - self.window_seconds
+        with self._lock:
+            self._global = [t for t in self._global if t > cutoff]
+            if len(self._global) >= self.max_global:
+                raise FediverseError('Demasiados registros de apps en este momento, intenta mas tarde')
+
+            domain_attempts = [t for t in self._by_domain.get(domain, []) if t > cutoff]
+            if len(domain_attempts) >= self.max_per_domain:
+                raise FediverseError(f"Demasiados intentos de registro para '{domain}', intenta mas tarde")
+
+            domain_attempts.append(now)
+            self._by_domain[domain] = domain_attempts
+            self._global.append(now)
+
+
+_registration_rate_limiter = _RegistrationRateLimiter(
+    REGISTRATION_RATE_WINDOW_SECONDS, REGISTRATION_RATE_MAX_PER_DOMAIN, REGISTRATION_RATE_MAX_GLOBAL,
+)
+
+
+def _is_public_ip(ip_text):
+    ip = ipaddress.ip_address(ip_text)
+    return not (
+        ip.is_private or ip.is_loopback or ip.is_link_local
+        or ip.is_multicast or ip.is_reserved or ip.is_unspecified
+    )
+
+
+def _assert_public_host(hostname):
+    try:
+        infos = socket.getaddrinfo(hostname, None)
+    except socket.gaierror as exc:
+        raise FediverseError(f"No se pudo resolver el dominio '{hostname}'") from exc
+    addresses = {info[4][0] for info in infos}
+    if not addresses:
+        raise FediverseError(f"No se pudo resolver el dominio '{hostname}'")
+    for address in addresses:
+        if not _is_public_ip(address):
+            raise FediverseError(f"El dominio '{hostname}' resuelve a una direccion no publica")
+
+
+def _safe_request(method, url, **kwargs):
+    """https-only, resuelve y valida el host antes de cada intento, sigue redirects a mano revalidando cada salto."""
+    for _ in range(MAX_REDIRECTS + 1):
+        parsed = urllib.parse.urlsplit(url)
+        if parsed.scheme != 'https':
+            raise FediverseError('Solo se permiten URLs https')
+        _assert_public_host(parsed.hostname)
+        response = requests.request(method, url, timeout=REQUEST_TIMEOUT, allow_redirects=False, **kwargs)
+        if response.is_redirect or response.is_permanent_redirect:
+            location = response.headers.get('Location')
+            if not location:
+                raise FediverseError('Redireccion sin Location')
+            url = urllib.parse.urljoin(url, location)
+            continue
+        return response
+    raise FediverseError('Demasiadas redirecciones')
+
+
+def parse_handle(handle):
+    """'@usuario@instancia' o 'usuario@instancia' -> (username, domain). Lanza FediverseError si es invalido."""
+    if not handle:
+        raise FediverseError('Escribe tu handle, por ejemplo usuario@instancia.social')
+    handle = handle.strip()
+    if handle.startswith('@'):
+        handle = handle[1:]
+    if '@' not in handle:
+        raise FediverseError('El handle debe tener la forma usuario@instancia')
+    username, _, domain = handle.partition('@')
+    username = username.strip()
+    domain = domain.strip().lower()
+    if not username or not domain or '.' not in domain or any(c.isspace() for c in domain):
+        raise FediverseError('El handle debe tener la forma usuario@instancia')
+    return username, domain
+
+
+def discover_nodeinfo(domain):
+    """Best-effort: confirma que el dominio responde como servidor real. Nunca bloquea el login."""
+    try:
+        response = _safe_request('GET', f'https://{domain}/.well-known/nodeinfo', headers={'Accept': 'application/json'})
+        if response.status_code != 200:
+            return None
+        links = response.json().get('links', [])
+        href = links[0].get('href') if links else None
+        if not href:
+            return None
+        info_response = _safe_request('GET', href, headers={'Accept': 'application/json'})
+        if info_response.status_code != 200:
+            return None
+        return info_response.json()
+    except (FediverseError, ValueError, requests.RequestException):
+        return None
+
+
+def discover_oauth_metadata(domain):
+    """RFC 8414. None en instancias que no lo exponen (comun en Pleroma/instancias viejas)."""
+    try:
+        response = _safe_request(
+            'GET', f'https://{domain}/.well-known/oauth-authorization-server',
+            headers={'Accept': 'application/json'},
+        )
+        if response.status_code != 200:
+            return None
+        return response.json()
+    except (FediverseError, ValueError, requests.RequestException):
+        return None
+
+
+def choose_scope(oauth_metadata):
+    supported = (oauth_metadata or {}).get('scopes_supported') or []
+    return SCOPE_MODERN if SCOPE_MODERN in supported else SCOPE_FALLBACK
+
+
+def supports_pkce(oauth_metadata):
+    methods = (oauth_metadata or {}).get('code_challenge_methods_supported') or []
+    return 'S256' in methods
+
+
+def register_app(domain, redirect_uri, scope, client_name='Honeycomb'):
+    _registration_rate_limiter.check_and_record(domain)
+    try:
+        response = _safe_request('POST', f'https://{domain}/api/v1/apps', data={
+            'client_name': client_name,
+            'redirect_uris': redirect_uri,
+            'scopes': scope,
+            'website': redirect_uri,
+        })
+    except requests.RequestException as exc:
+        raise FediverseError(f"No se pudo registrar la app en {domain}") from exc
+    if response.status_code >= 400:
+        raise FediverseError(f"{domain} rechazo el registro de la app")
+    payload = response.json()
+    client_id = payload.get('client_id')
+    client_secret = payload.get('client_secret')
+    if not client_id or not client_secret:
+        raise FediverseError(f"{domain} no devolvio credenciales de app validas")
+    return client_id, client_secret
+
+
+def generate_pkce_pair():
+    verifier = base64.urlsafe_b64encode(secrets.token_bytes(64)).rstrip(b'=').decode('ascii')
+    digest = hashlib.sha256(verifier.encode('ascii')).digest()
+    challenge = base64.urlsafe_b64encode(digest).rstrip(b'=').decode('ascii')
+    return verifier, challenge
+
+
+def new_state():
+    return secrets.token_urlsafe(32)
+
+
+def states_match(expected, received):
+    if not expected or not received:
+        return False
+    return hmac.compare_digest(expected, received)
+
+
+def build_authorize_url(domain, client_id, redirect_uri, state, scope, code_challenge=None):
+    params = {
+        'response_type': 'code',
+        'client_id': client_id,
+        'redirect_uri': redirect_uri,
+        'scope': scope,
+        'state': state,
+    }
+    if code_challenge:
+        params['code_challenge'] = code_challenge
+        params['code_challenge_method'] = 'S256'
+    return f'https://{domain}/oauth/authorize?' + urllib.parse.urlencode(params)
+
+
+def exchange_code(domain, client_id, client_secret, redirect_uri, code, scope, code_verifier=None):
+    data = {
+        'grant_type': 'authorization_code',
+        'client_id': client_id,
+        'client_secret': client_secret,
+        'redirect_uri': redirect_uri,
+        'code': code,
+        'scope': scope,
+    }
+    if code_verifier:
+        data['code_verifier'] = code_verifier
+    try:
+        response = _safe_request('POST', f'https://{domain}/oauth/token', data=data)
+    except requests.RequestException as exc:
+        raise FediverseError(f"No se pudo intercambiar el codigo con {domain}") from exc
+    if response.status_code >= 400:
+        raise FediverseError(f"{domain} rechazo el intercambio de codigo")
+    token = response.json().get('access_token')
+    if not token:
+        raise FediverseError(f"{domain} no devolvio un access_token")
+    return token
+
+
+def fetch_account(domain, access_token):
+    try:
+        response = _safe_request(
+            'GET', f'https://{domain}/api/v1/accounts/verify_credentials',
+            headers={'Authorization': f'Bearer {access_token}'},
+        )
+    except requests.RequestException as exc:
+        raise FediverseError(f"No se pudo obtener el perfil desde {domain}") from exc
+    if response.status_code >= 400:
+        raise FediverseError(f"{domain} rechazo verify_credentials")
+    return response.json()
+
+
+def _image_url(value):
+    if isinstance(value, str):
+        return value or None
+    if isinstance(value, dict):
+        return _image_url(value.get('url'))
+    if isinstance(value, list) and value:
+        return _image_url(value[0])
+    return None
+
+
+def canonical_userid(domain, account):
+    """Actor URI si esta disponible (identidad ActivityPub nativa); si no, host+id como respaldo estable."""
+    actor_uri = account.get('uri')
+    if actor_uri:
+        return actor_uri
+    return f"{domain}#{account.get('id')}"
+
+
+def account_to_drone_user(domain, account):
+    userid = canonical_userid(domain, account)
+    username = account.get('username') or account.get('acct') or ''
+    handle = account.get('acct') or username
+    if handle and '@' not in handle:
+        handle = f'{handle}@{domain}'
+    display_name = account.get('display_name') or username
+    icon = _image_url(account.get('avatar') or account.get('avatar_static') or account.get('icon'))
+    background = _image_url(account.get('header') or account.get('header_static') or account.get('image'))
+    return DroneUser(userid=userid, display_name=display_name, username=handle, icon=icon, background=background)

--- a/honeycomb/security/local_accounts.py
+++ b/honeycomb/security/local_accounts.py
@@ -1,0 +1,158 @@
+"""Registro y login de cuentas locales (usuario + contrasena): alternativa al
+login por Fediverso para quien no tiene cuenta en ninguna instancia. Deshabilitado
+por defecto -- lo activa quien administra la instancia con honeycomb.local_accounts.
+
+Sin correo en el proyecto no hay verificacion de cuenta ni recuperacion de
+contrasena: quien pierde su contrasena pierde el acceso a esa credencial (puede
+seguir entrando por cualquier otra que tenga vinculada). Es responsabilidad de
+la pantalla de registro dejarlo claro, no solo de este modulo.
+
+Ver security/passwords.py para el hasheo y security/ratelimit.py para los limites.
+"""
+
+import uuid
+
+from . import ratelimit
+from .passwords import CredentialError, hash_password, normalize_username, validate_password, verify_password
+from ..models.users import DroneUser
+
+DEFAULT_MIN_PASSWORD_LENGTH = 10
+DEFAULT_LOGIN_RATE_WINDOW_SECONDS = 300
+DEFAULT_LOGIN_RATE_MAX_PER_USER = 10
+DEFAULT_LOGIN_RATE_MAX_GLOBAL = 100
+
+
+class LocalAuthError(Exception):
+    """Cuentas locales deshabilitadas, credenciales invalidas, o demasiados
+    intentos. El mensaje es siempre generico en login para no revelar si un
+    nombre de usuario existe (ver authenticate)."""
+
+
+_login_rate_limiter = ratelimit.SlidingWindowLimiter(
+    DEFAULT_LOGIN_RATE_WINDOW_SECONDS, DEFAULT_LOGIN_RATE_MAX_PER_USER, DEFAULT_LOGIN_RATE_MAX_GLOBAL,
+)
+_registration_rate_limiter = ratelimit.SlidingWindowLimiter(
+    DEFAULT_LOGIN_RATE_WINDOW_SECONDS, None, DEFAULT_LOGIN_RATE_MAX_GLOBAL,
+)
+
+
+def configure_rate_limiters(settings):
+    """Llamado una vez al arrancar la app (security/__init__.py:includeme) para
+    que los limites de login/registro local reflejen lo configurado en el .ini."""
+    global _login_rate_limiter, _registration_rate_limiter
+    window = ratelimit.positive_int_setting(
+        settings, 'honeycomb.login_rate_window_seconds', DEFAULT_LOGIN_RATE_WINDOW_SECONDS,
+    )
+    login_max_per_user = ratelimit.limit_setting_or_none(settings, 'honeycomb.login_rate_max_per_user')
+    login_max_global = ratelimit.limit_setting_or_none(settings, 'honeycomb.login_rate_max_global')
+    _login_rate_limiter = ratelimit.SlidingWindowLimiter(window, login_max_per_user, login_max_global)
+
+    registration_max_global = ratelimit.limit_setting_or_none(settings, 'honeycomb.registration_rate_max_global')
+    _registration_rate_limiter = ratelimit.SlidingWindowLimiter(window, None, registration_max_global)
+
+
+def is_enabled(settings):
+    return (settings.get('honeycomb.local_accounts') or '').strip().lower() in ('1', 'true', 'yes', 'on')
+
+
+def _min_password_length(settings):
+    return ratelimit.positive_int_setting(settings, 'honeycomb.min_password_length', DEFAULT_MIN_PASSWORD_LENGTH)
+
+
+def register(root, settings, raw_username, password):
+    """Crea una cuenta local nueva. userid opaco (local:<uuid>): el nombre de
+    usuario no es la llave de la base de datos, se puede cambiar despues sin
+    romper el progreso."""
+    if not is_enabled(settings):
+        raise LocalAuthError('El registro de cuentas locales no esta habilitado en este servidor')
+
+    try:
+        username = normalize_username(raw_username)
+        validate_password(password, min_length=_min_password_length(settings))
+    except CredentialError as exc:
+        raise LocalAuthError(str(exc)) from exc
+
+    try:
+        _registration_rate_limiter.check_and_record('register')
+    except ratelimit.RateLimitError as exc:
+        raise LocalAuthError('Demasiados registros en este momento, intenta mas tarde') from exc
+
+    identity_key = f'password:{username}'
+    if root.resolve_identity(identity_key) is not None:
+        # Mismo mensaje generico que un login fallido: no confirmar si el
+        # nombre esta tomado desde una respuesta que un bot pueda automatizar
+        # seria mejor, pero en registro el usuario ya eligio el nombre a
+        # proposito, asi que aqui si tiene sentido decirlo con claridad.
+        raise LocalAuthError('Ese nombre de usuario ya esta en uso')
+
+    userid = f'local:{uuid.uuid4()}'
+    user = DroneUser(
+        userid=userid, display_name=username, username=username,
+        password_hash=hash_password(password),
+    )
+    root.upsert_user(user)
+    root.link_identity(identity_key, userid)
+    return user
+
+
+def authenticate(root, settings, raw_username, password):
+    """None de los caminos de fallo revela si el usuario existe: 'no existe' y
+    'contrasena incorrecta' dan exactamente el mismo error."""
+    if not is_enabled(settings):
+        raise LocalAuthError('El login local no esta habilitado en este servidor')
+
+    username = (raw_username or '').strip().lower()
+    try:
+        _login_rate_limiter.check_and_record(username or '(en blanco)')
+    except ratelimit.RateLimitError as exc:
+        raise LocalAuthError('Demasiados intentos, espera un momento e intenta de nuevo') from exc
+
+    generic_error = LocalAuthError('Usuario o contrasena incorrectos')
+    userid = root.resolve_identity(f'password:{username}')
+    if userid is None:
+        raise generic_error
+    user = root.get_user(userid)
+    if user is None or not user.password_hash:
+        raise generic_error
+    if not verify_password(password, user.password_hash):
+        raise generic_error
+    return user
+
+
+def link_password(root, settings, existing_user, raw_username, password):
+    """Le agrega una credencial de contrasena a una cuenta ya autenticada (p.ej.
+    una que empezo por Fediverso). No toca el username de perfil del usuario --
+    el nombre local es solo la llave de login, no reemplaza el nombre mostrado."""
+    if not is_enabled(settings):
+        raise LocalAuthError('El registro de cuentas locales no esta habilitado en este servidor')
+
+    try:
+        username = normalize_username(raw_username)
+        validate_password(password, min_length=_min_password_length(settings))
+    except CredentialError as exc:
+        raise LocalAuthError(str(exc)) from exc
+
+    identity_key = f'password:{username}'
+    existing_link = root.resolve_identity(identity_key)
+    if existing_link is not None and existing_link != existing_user.userid:
+        raise LocalAuthError('Ese nombre de usuario ya esta en uso')
+
+    existing_user.password_hash = hash_password(password)
+    root.link_identity(identity_key, existing_user.userid)
+    return existing_user
+
+
+def unlink(root, userid, identity_key):
+    """Se niega a quitar la ultima credencial de la cuenta: sin eso, la cuenta
+    quedaria sin ninguna forma de volver a entrar."""
+    linked_keys = list(root.iter_identities(userid))
+    if identity_key not in linked_keys:
+        raise LocalAuthError('Esa credencial no esta vinculada a tu cuenta')
+    if len(linked_keys) <= 1:
+        raise LocalAuthError('No puedes desvincular tu unica credencial de acceso')
+
+    root.unlink_identity(identity_key)
+    if identity_key.startswith('password:'):
+        user = root.get_user(userid)
+        if user is not None:
+            user.password_hash = None

--- a/honeycomb/security/passwords.py
+++ b/honeycomb/security/passwords.py
@@ -1,0 +1,72 @@
+"""Hasheo de contrasenas de cuentas locales, con hashlib.scrypt (stdlib).
+
+No agrega dependencias: scrypt ya viene con Python via OpenSSL. El formato de
+salida lleva sus propios parametros para poder subir el costo mas adelante sin
+invalidar los hashes ya guardados.
+"""
+
+import base64
+import hashlib
+import hmac
+import re
+import secrets
+
+SCRYPT_N = 16384
+SCRYPT_R = 8
+SCRYPT_P = 1
+SALT_BYTES = 16
+
+USERNAME_RE = re.compile(r'^[a-z0-9_-]{3,32}$')
+
+
+class CredentialError(Exception):
+    """Nombre de usuario o contrasena que no cumple la politica de cuentas locales."""
+
+
+def hash_password(password):
+    salt = secrets.token_bytes(SALT_BYTES)
+    digest = hashlib.scrypt(password.encode('utf-8'), salt=salt, n=SCRYPT_N, r=SCRYPT_R, p=SCRYPT_P)
+    salt_b64 = base64.b64encode(salt).decode('ascii')
+    digest_b64 = base64.b64encode(digest).decode('ascii')
+    return f'scrypt$n={SCRYPT_N},r={SCRYPT_R},p={SCRYPT_P}${salt_b64}${digest_b64}'
+
+
+def verify_password(password, stored):
+    """Nunca lanza: un hash corrupto o de un formato distinto simplemente no verifica."""
+    try:
+        scheme, params, salt_b64, digest_b64 = stored.split('$')
+        if scheme != 'scrypt':
+            return False
+        kwargs = {}
+        for part in params.split(','):
+            key, value = part.split('=')
+            kwargs[key] = int(value)
+        salt = base64.b64decode(salt_b64)
+        expected = base64.b64decode(digest_b64)
+        candidate = hashlib.scrypt(
+            password.encode('utf-8'), salt=salt,
+            n=kwargs['n'], r=kwargs['r'], p=kwargs['p'],
+        )
+        return hmac.compare_digest(candidate, expected)
+    except Exception:
+        return False
+
+
+def validate_password(password, min_length=10):
+    if not password or len(password) < min_length:
+        raise CredentialError(f'La contrasena debe tener al menos {min_length} caracteres')
+
+
+def normalize_username(raw):
+    """Minusculas, sin espacios, charset limitado a letras/numeros/guion/guion bajo.
+
+    Prohibe '@', ':' y '/' a proposito: un nombre local nunca debe poder
+    confundirse con un handle del Fediverso (usuario@dominio) ni con una URL
+    de actor, porque ambas formas conviven como claves en __identities__.
+    """
+    username = (raw or '').strip().lower()
+    if not USERNAME_RE.match(username):
+        raise CredentialError(
+            'El nombre de usuario debe tener 3-32 caracteres: minusculas, numeros, guion o guion bajo'
+        )
+    return username

--- a/honeycomb/security/policy.py
+++ b/honeycomb/security/policy.py
@@ -1,14 +1,11 @@
 from pyramid.authentication import AuthTktCookieHelper
 from pyramid.request import RequestLocalCache
 from pyramid.security import Allowed, Denied
+from pyramid_zodbconn import get_connection
 
+from ..models import appmaker
 from ..models.axes import CellBuilder
-from ..models.users import DroneUser
 
-
-USERS = {
-    'convida@unam.social': DroneUser('convida@unam.social', 'Convida UNAM', 'convida@unam.social', '/static/bumblebee-512x512.png', '/static/honeycomb.png'),
-}
 
 class SecurityPolicy:
     def __init__(self, secret):
@@ -17,18 +14,13 @@ class SecurityPolicy:
 
     def load_identity(self, request):
         identity = self.authtkt.identify(request)
-        
+
         if identity is None:
             return None
 
         userid = identity['userid']
-
-        if userid not in USERS:
-            return None
-
-        identity = USERS[userid]
-
-        return identity
+        root = appmaker(get_connection(request).root())
+        return root.get_user(userid)
 
     def identity(self, request):
         return self.identity_cache.get_or_create(request)
@@ -52,7 +44,7 @@ class SecurityPolicy:
             return Denied("You need to sign in to view this contents")
         elif permission == 'read':
             if CellBuilder.has_access(context, identity):
-                return Allowed('Access granted for user %s', identity['username'])
+                return Allowed('Access granted for user %s', identity.username)
             else:
                 return Denied("You are not allowed to access this resource")
         else:

--- a/honeycomb/security/ratelimit.py
+++ b/honeycomb/security/ratelimit.py
@@ -1,0 +1,75 @@
+"""Limitador de tasa de ventana deslizante, en memoria de proceso.
+
+Reusado por el registro de apps OAuth por dominio (security/fediverse.py) y
+por los intentos de login/registro de cuentas locales (views/local_auth.py).
+En memoria de un solo proceso (un worker via waitress); si el proyecto llega a
+desplegarse con varios workers, esto debe moverse a un almacen compartido
+(p.ej. la misma ZODB, o un cache externo).
+"""
+
+import threading
+import time
+
+
+class RateLimitError(Exception):
+    """Se alcanzo el limite configurado. scope es 'global' o 'key' segun cual."""
+
+    def __init__(self, scope):
+        self.scope = scope
+        super().__init__(scope)
+
+
+class SlidingWindowLimiter:
+    """Limita cuantas veces se puede llamar check_and_record: por clave y en total.
+
+    max_per_key/max_global en None desactiva ese eje (sin limite).
+    """
+
+    def __init__(self, window_seconds, max_per_key, max_global):
+        self.window_seconds = window_seconds
+        self.max_per_key = max_per_key
+        self.max_global = max_global
+        self._lock = threading.Lock()
+        self._by_key = {}
+        self._global = []
+
+    def check_and_record(self, key):
+        now = time.monotonic()
+        cutoff = now - self.window_seconds
+        with self._lock:
+            self._global = [t for t in self._global if t > cutoff]
+            if self.max_global is not None and len(self._global) >= self.max_global:
+                raise RateLimitError('global')
+
+            key_attempts = [t for t in self._by_key.get(key, []) if t > cutoff]
+            if self.max_per_key is not None and len(key_attempts) >= self.max_per_key:
+                raise RateLimitError('key')
+
+            key_attempts.append(now)
+            self._by_key[key] = key_attempts
+            self._global.append(now)
+
+
+def positive_int_setting(settings, key, default):
+    """Para valores que siempre necesitan un numero (p.ej. una ventana de tiempo)."""
+    raw = (settings.get(key) or '').strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
+def limit_setting_or_none(settings, key):
+    """Para topes configurables: vacio/ausente/<=0 = sin limite. Por defecto (sin
+    configurar) el tope esta desactivado -- lo activa quien administra la instancia."""
+    raw = (settings.get(key) or '').strip()
+    if not raw:
+        return None
+    try:
+        value = int(raw)
+    except ValueError:
+        return None
+    return value if value > 0 else None

--- a/honeycomb/security/tokenstore.py
+++ b/honeycomb/security/tokenstore.py
@@ -1,0 +1,56 @@
+"""Cifrado en reposo del access_token de OAuth del Fediverso.
+
+Sin honeycomb.token_encryption_key configurada, el token nunca se guarda -- ni
+en claro ni de ninguna otra forma. Publicar al Fediverso a nombre del usuario
+queda deshabilitado hasta que quien administra la instancia provea una clave.
+"""
+
+from cryptography.fernet import Fernet, InvalidToken
+
+
+class TokenStoreError(Exception):
+    """Clave mal configurada, o token guardado que ya no se puede descifrar."""
+
+
+def _fernet(settings):
+    raw_key = (settings.get('honeycomb.token_encryption_key') or '').strip()
+    if not raw_key:
+        return None
+    try:
+        return Fernet(raw_key.encode('ascii'))
+    except (ValueError, TypeError) as exc:
+        raise TokenStoreError(
+            "honeycomb.token_encryption_key no es una clave Fernet valida "
+            "(genera una con tokenstore.generate_key())"
+        ) from exc
+
+
+def is_configured(settings):
+    return _fernet(settings) is not None
+
+
+def encrypt_token(settings, access_token):
+    """None si no hay clave configurada: el llamador decide si eso bloquea la accion."""
+    if not access_token:
+        return None
+    fernet = _fernet(settings)
+    if fernet is None:
+        return None
+    return fernet.encrypt(access_token.encode('utf-8')).decode('ascii')
+
+
+def decrypt_token(settings, encrypted_token):
+    if not encrypted_token:
+        return None
+    fernet = _fernet(settings)
+    if fernet is None:
+        raise TokenStoreError('No hay honeycomb.token_encryption_key configurada en este servidor')
+    try:
+        return fernet.decrypt(encrypted_token.encode('ascii')).decode('utf-8')
+    except InvalidToken as exc:
+        raise TokenStoreError('El token guardado no se pudo descifrar (se roto la clave?)') from exc
+
+
+def generate_key():
+    """Utilidad para el administrador de la instancia: genera una clave Fernet nueva."""
+    return Fernet.generate_key().decode('ascii')

--- a/honeycomb/static/sdk/honeycomb.js
+++ b/honeycomb/static/sdk/honeycomb.js
@@ -38,7 +38,7 @@ window.Honeycomb = (function () {
   HoneycombSession.prototype.load = function (nodeId) {
     var id = nodeId || this.nodeId;
     if (!id) return Promise.reject(new Error('Honeycomb: nodeId is required'));
-    return request('/games/' + encodeURIComponent(id) + '/data');
+    return request('/sipping/' + encodeURIComponent(id));
   };
 
   HoneycombSession.prototype.save = function (nodeId, data) {
@@ -49,7 +49,7 @@ window.Honeycomb = (function () {
       id = this.nodeId;
     }
     if (!id) return Promise.reject(new Error('Honeycomb: nodeId is required'));
-    return request('/games/' + encodeURIComponent(id) + '/data', {
+    return request('/sipping/' + encodeURIComponent(id), {
       method: 'POST',
       body: JSON.stringify(payload || {}),
     });

--- a/honeycomb/static/sdk/honeycomb.js
+++ b/honeycomb/static/sdk/honeycomb.js
@@ -1,9 +1,16 @@
 // SDK homologado para que los videojuegos hablen con la API de Honeycomb.
 // Uso:
 //   const hc = await Honeycomb.connect();
-//   hc.user;                                   // {userid, displayname, username, icon, background}
+//   hc.user;                                   // {userid, displayname, username, icon, background,
+//                                               //  identities: [{kind, value}, ...], can_share}
 //   const data = await hc.load(nodeId);         // {interactions, stats, preferences, badges, ...}
 //   await hc.save(nodeId, { stats: {...}, preferences: {...} });
+//   await hc.awardBadge(nodeId, { id: 'high-score-100', title: 'Cien puntos', icon: '🏆' });
+//   const mine = await hc.achievements();        // {achievements: [{id, title, icon, nodeid, ...}]}
+//   if (hc.user.can_share) await hc.share(nodeId, 'high-score-100'); // publica el logro al Fediverso
+//   // El usuario pudo entrar por el Fediverso, por usuario/contrasena, o ambos si los vinculo desde
+//   // /cuenta -- can_share solo es true cuando hay una identidad del Fediverso vinculada Y un token
+//   // de publicacion guardado (honeycomb.token_encryption_key configurada en el servidor).
 window.Honeycomb = (function () {
   var API_BASE = '/api/v1';
 
@@ -52,6 +59,35 @@ window.Honeycomb = (function () {
     return request('/sipping/' + encodeURIComponent(id), {
       method: 'POST',
       body: JSON.stringify(payload || {}),
+    });
+  };
+
+  HoneycombSession.prototype.awardBadge = function (nodeId, badge) {
+    var id = nodeId;
+    var payload = badge;
+    if (typeof nodeId === 'object') {
+      payload = nodeId;
+      id = this.nodeId;
+    }
+    if (!id) return Promise.reject(new Error('Honeycomb: nodeId is required'));
+    return request('/sipping/' + encodeURIComponent(id) + '/badges', {
+      method: 'POST',
+      body: JSON.stringify(payload || {}),
+    });
+  };
+
+  HoneycombSession.prototype.achievements = function () {
+    return request('/achievements');
+  };
+
+  HoneycombSession.prototype.share = function (nodeId, badgeId, message) {
+    var id = nodeId || this.nodeId;
+    if (!id) return Promise.reject(new Error('Honeycomb: nodeId is required'));
+    var payload = { nodeid: id, badge_id: badgeId };
+    if (message) payload.message = message;
+    return request('/share', {
+      method: 'POST',
+      body: JSON.stringify(payload),
     });
   };
 

--- a/honeycomb/static/sdk/honeycomb.js
+++ b/honeycomb/static/sdk/honeycomb.js
@@ -1,0 +1,65 @@
+// SDK homologado para que los videojuegos hablen con la API de Honeycomb.
+// Uso:
+//   const hc = await Honeycomb.connect();
+//   hc.user;                                   // {userid, displayname, username, icon, background}
+//   const data = await hc.load(nodeId);         // {interactions, stats, preferences, badges, ...}
+//   await hc.save(nodeId, { stats: {...}, preferences: {...} });
+window.Honeycomb = (function () {
+  var API_BASE = '/api/v1';
+
+  function detectNodeId() {
+    var params = new URLSearchParams(window.location.search);
+    if (params.has('nodeid')) return params.get('nodeid');
+    var script = document.currentScript;
+    if (script && script.dataset && script.dataset.nodeId) return script.dataset.nodeId;
+    return null;
+  }
+
+  function request(path, options) {
+    var opts = Object.assign({
+      credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json' },
+    }, options);
+    return fetch(API_BASE + path, opts).then(function (response) {
+      if (!response.ok) {
+        var error = new Error('Honeycomb API error ' + response.status);
+        error.status = response.status;
+        throw error;
+      }
+      return response.json();
+    });
+  }
+
+  function HoneycombSession(user, nodeId) {
+    this.user = user;
+    this.nodeId = nodeId || null;
+  }
+
+  HoneycombSession.prototype.load = function (nodeId) {
+    var id = nodeId || this.nodeId;
+    if (!id) return Promise.reject(new Error('Honeycomb: nodeId is required'));
+    return request('/games/' + encodeURIComponent(id) + '/data');
+  };
+
+  HoneycombSession.prototype.save = function (nodeId, data) {
+    var id = nodeId;
+    var payload = data;
+    if (typeof nodeId === 'object') {
+      payload = nodeId;
+      id = this.nodeId;
+    }
+    if (!id) return Promise.reject(new Error('Honeycomb: nodeId is required'));
+    return request('/games/' + encodeURIComponent(id) + '/data', {
+      method: 'POST',
+      body: JSON.stringify(payload || {}),
+    });
+  };
+
+  function connect(nodeId) {
+    return request('/me').then(function (user) {
+      return new HoneycombSession(user, nodeId || detectNodeId());
+    });
+  }
+
+  return { connect: connect };
+})();

--- a/honeycomb/templates/beehive.jinja2
+++ b/honeycomb/templates/beehive.jinja2
@@ -4,7 +4,7 @@
 <div class="content">
   <h1><span class="font-semi-bold">{{ project }}</span></h1>
   <p class="lead">
-      Welcome to the BeeHive{% if request.authenticated_userid %}: <span class="text-info">{{ request.identity["display_name"] }}</span>{% endif %}. You are currently visiting
+      Welcome to the BeeHive{% if request.authenticated_userid %}: <span class="text-info">{{ request.identity.display_name }}</span>{% endif %}. You are currently visiting
     <span class="font-normal">{{ title or "Demo Beehive" }}</span>.
     Please look at the contents which are here available.
   </p>

--- a/honeycomb/templates/cuenta.jinja2
+++ b/honeycomb/templates/cuenta.jinja2
@@ -1,0 +1,78 @@
+{% extends "layout.jinja2" %}
+
+{% block header %}
+    <div class="header row">
+        <div class="col text-center">
+             <h2><span class="font-semi-bold">Tu cuenta</span></h2>
+        </div>
+    </div>
+{% endblock %}
+
+{% block content %}
+<div class="content row">
+    <div class="col-md-8">
+      {% if error %}
+      <div class="alert alert-danger">{{ error }}</div>
+      {% endif %}
+
+      <p class="text-muted">
+        <small>
+          Cada credencial de aqui abajo da acceso a la misma cuenta y al mismo progreso. Entrar por el
+          Fediverso o por usuario/contraseña sin vincularlos primero crea (o entra a) cuentas distintas.
+        </small>
+      </p>
+
+      <h3>Credenciales vinculadas</h3>
+      <ul>
+        {% for identity_key in identities %}
+          <li>
+            {% if identity_key.startswith('fediverse:') %}
+              Fediverso: {{ identity_key[10:] }}
+            {% elif identity_key.startswith('password:') %}
+              Usuario y contraseña: {{ identity_key[9:] }}
+            {% else %}
+              {{ identity_key }}
+            {% endif %}
+            {% if identities|length > 1 %}
+              <form method="post" action="/api/v1/auth/unlink" style="display:inline" id="unlink-form-{{ loop.index }}">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+                <input type="hidden" name="identity_key" value="{{ identity_key }}">
+                <input type="submit" class="btn btn-xs btn-default" value="Desvincular">
+              </form>
+            {% endif %}
+          </li>
+        {% endfor %}
+      </ul>
+
+      <h3>Vincular el Fediverso</h3>
+      <form method="post" action="/api/v1/auth/login" id="link-fediverse-form">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+        <input type="hidden" name="next" value="/cuenta">
+        <div class="form-group">
+          <label for="handle">Tu usuario del Fediverso</label>
+          <input type="text" class="form-control" id="handle" name="handle" placeholder="usuario@instancia.social" required>
+        </div>
+        <input type="submit" class="btn btn-primary" value="Vincular">
+      </form>
+
+      {% if local_accounts_enabled %}
+      <h3>Vincular usuario y contraseña</h3>
+      {% if has_password %}
+      <p class="text-muted"><small>Ya tienes una contraseña vinculada. Vincular una nueva la reemplaza.</small></p>
+      {% endif %}
+      <form method="post" action="/api/v1/auth/link/password" id="link-password-form">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+        <div class="form-group">
+          <label for="username">Usuario</label>
+          <input type="text" class="form-control" id="username" name="username" required>
+        </div>
+        <div class="form-group">
+          <label for="password">Contraseña</label>
+          <input type="password" class="form-control" id="password" name="password" required>
+        </div>
+        <input type="submit" class="btn btn-primary" value="Vincular">
+      </form>
+      {% endif %}
+    </div>
+</div>
+{% endblock content %}

--- a/honeycomb/templates/login.jinja2
+++ b/honeycomb/templates/login.jinja2
@@ -11,10 +11,21 @@
 {% block content %}
 <div class="content row">
     <div class="col-md-8">
+      {% if error %}
+      <div class="alert alert-danger">{{ error }}</div>
+      {% endif %}
       {% if login_form %}
          {{ login_form|safe }}
       {% else %}
-          <form><input type="submit" value="login"></form>
+          <form method="post" action="/api/v1/auth/login">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+            <input type="hidden" name="next" value="{{ next_url }}">
+            <div class="form-group">
+              <label for="handle">Tu usuario del Fediverso</label>
+              <input type="text" class="form-control" id="handle" name="handle" placeholder="usuario@instancia.social" required>
+            </div>
+            <input type="submit" class="btn btn-primary" value="Iniciar sesión">
+          </form>
       {% endif %}
       {% if appstruct %}
       {{ appstruct }}

--- a/honeycomb/templates/login.jinja2
+++ b/honeycomb/templates/login.jinja2
@@ -17,7 +17,7 @@
       {% if login_form %}
          {{ login_form|safe }}
       {% else %}
-          <form method="post" action="/api/v1/auth/login">
+          <form method="post" action="/api/v1/auth/login" id="fediverse-login-form">
             <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
             <input type="hidden" name="next" value="{{ next_url }}">
             <div class="form-group">
@@ -26,6 +26,30 @@
             </div>
             <input type="submit" class="btn btn-primary" value="Iniciar sesión">
           </form>
+
+          <hr>
+
+          <form method="post" action="/api/v1/auth/local" id="local-login-form">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+            <input type="hidden" name="next" value="{{ next_url }}">
+            <div class="form-group">
+              <label for="username">Usuario</label>
+              <input type="text" class="form-control" id="username" name="username" required>
+            </div>
+            <div class="form-group">
+              <label for="password">Contraseña</label>
+              <input type="password" class="form-control" id="password" name="password" required>
+            </div>
+            <input type="submit" class="btn btn-default" value="Iniciar sesión con usuario y contraseña">
+          </form>
+
+          <p class="text-muted">
+            <small>
+              El Fediverso y usuario/contraseña son cuentas distintas: entrar por uno u otro no te da
+              acceso al progreso del otro, a menos que las vincules desde <a href="/cuenta">tu cuenta</a>.
+              ¿No tienes cuenta? <a href="/register">Regístrate</a>.
+            </small>
+          </p>
       {% endif %}
       {% if appstruct %}
       {{ appstruct }}

--- a/honeycomb/templates/register.jinja2
+++ b/honeycomb/templates/register.jinja2
@@ -1,0 +1,49 @@
+{% extends "layout.jinja2" %}
+
+{% block header %}
+    <div class="header row">
+        <div class="col text-center">
+             <h2><span class="font-semi-bold">Registro</span></h2>
+        </div>
+    </div>
+{% endblock %}
+
+{% block content %}
+<div class="content row">
+    <div class="col-md-8">
+      {% if error %}
+      <div class="alert alert-danger">{{ error }}</div>
+      {% endif %}
+      {% if not enabled %}
+      <div class="alert alert-warning">
+        El registro de cuentas locales no esta habilitado en este servidor. Entra con tu cuenta del
+        <a href="/login">Fediverso</a>.
+      </div>
+      {% else %}
+          <p class="text-muted">
+            <small>
+              Este servidor no tiene correo configurado: no hay forma de recuperar una contraseña
+              olvidada. Si pierdes tu contraseña, pierdes esta credencial (podras seguir entrando por
+              cualquier otra que hayas vinculado desde <a href="/cuenta">tu cuenta</a>).
+            </small>
+          </p>
+          <form method="post" action="/api/v1/auth/register" id="register-form">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+            <input type="hidden" name="next" value="{{ next_url }}">
+            <div class="form-group">
+              <label for="username">Usuario</label>
+              <input type="text" class="form-control" id="username" name="username" required>
+            </div>
+            <div class="form-group">
+              <label for="password">Contraseña</label>
+              <input type="password" class="form-control" id="password" name="password" required>
+            </div>
+            <input type="submit" class="btn btn-primary" value="Crear cuenta">
+          </form>
+          <p class="text-muted">
+            <small>¿Ya tienes cuenta? <a href="/login">Inicia sesión</a>.</small>
+          </p>
+      {% endif %}
+    </div>
+</div>
+{% endblock content %}

--- a/honeycomb/views/api.py
+++ b/honeycomb/views/api.py
@@ -3,6 +3,7 @@ import math
 from cornice.resource import resource
 from pyramid import traversal
 from ..models import *
+from ..security import activitypub, fediverse, ratelimit, tokenstore
 import logging
 
 log = logging.getLogger(__name__)
@@ -230,6 +231,14 @@ class UserIDResource:
         }
 
 
+def _identity_to_dict(identity_key):
+    """'fediverse:<actor_url>' / 'password:<username>' -> {'kind', 'value'};
+    partition corta solo en el primer ':', asi que una URL de actor con sus
+    propios ':' (https://...) se conserva entera en value."""
+    kind, _, value = identity_key.partition(':')
+    return {'kind': kind, 'value': value}
+
+
 @resource(path='/api/v1/me', cors_origins=('*',), factory='honeycomb.root_factory')
 class MeResource:
     """Datos de solo lectura del usuario autenticado. Contrato homologado (a)."""
@@ -243,23 +252,32 @@ class MeResource:
         if not user:
             self.request.response.status = 401
             return {'error': 'Unauthorized'}
+        root = traversal.find_root(resource=self.context)
+        identities = [_identity_to_dict(key) for key in root.iter_identities(user.userid)]
         return {
             'userid': user.userid,
             'displayname': user.display_name,
             'username': user.username,
             'icon': user.icon,
             'background': user.background,
+            # Credenciales vinculadas a esta cuenta (Fediverso y/o contrasena) y
+            # si hay lo necesario para publicar logros al Fediverso ahora mismo.
+            'identities': identities,
+            'can_share': user.can_share(),
         }
 
 
-MAX_GAME_PAYLOAD_KEYS = 100
+def _max_game_payload_keys(settings):
+    """Vacio/ausente/<=0 = sin limite; lo activa quien administra la instancia
+    poniendo un entero positivo en honeycomb.max_game_payload_keys."""
+    return ratelimit.limit_setting_or_none(settings, 'honeycomb.max_game_payload_keys')
 
 
-def _validate_game_payload(mapping, field_name):
+def _validate_game_payload(mapping, field_name, max_keys):
     if not isinstance(mapping, dict):
         return f"'{field_name}' must be an object"
-    if len(mapping) > MAX_GAME_PAYLOAD_KEYS:
-        return f"'{field_name}' has too many keys (max {MAX_GAME_PAYLOAD_KEYS})"
+    if max_keys is not None and len(mapping) > max_keys:
+        return f"'{field_name}' has too many keys (max {max_keys})"
     return None
 
 
@@ -304,7 +322,8 @@ class GameDataResource:
         preferences = payload.get('preferences', {})
         replace = bool(payload.get('replace', False))
 
-        error = _validate_game_payload(stats, 'stats') or _validate_game_payload(preferences, 'preferences')
+        max_keys = _max_game_payload_keys(self.request.registry.settings)
+        error = _validate_game_payload(stats, 'stats', max_keys) or _validate_game_payload(preferences, 'preferences', max_keys)
         if error:
             self.request.response.status = 400
             return {'error': error}
@@ -316,3 +335,136 @@ class GameDataResource:
         record.merge_preferences(preferences, replace=replace)
         record.register_interaction()
         return record.to_dict()
+
+
+@resource(path='/api/v1/sipping/{nodeid}/badges', cors_origins=('*',), factory='honeycomb.root_factory', require_csrf=False)
+class GameBadgeResource:
+    """Otorga logros (badges) al usuario autenticado para un nodo. Solo escritura
+    controlada por el juego que llama; el cliente del juego decide que logro
+    otorgar y con que datos, igual que con `stats`."""
+
+    def __init__(self, request, context=None):
+        self.request = request
+        self.context = context
+
+    def post(self):
+        user = getattr(self.request, 'identity', None)
+        if not user:
+            self.request.response.status = 401
+            return {'error': 'Unauthorized'}
+
+        nodeid = self.request.matchdict['nodeid']
+        try:
+            payload = self.request.json_body
+        except Exception:
+            self.request.response.status = 400
+            return {'error': 'Invalid JSON'}
+        if not isinstance(payload, dict):
+            self.request.response.status = 400
+            return {'error': 'Request body must be a JSON object'}
+
+        badge_id = payload.get('id')
+        title = payload.get('title')
+        icon = payload.get('icon')
+        if not badge_id or not isinstance(badge_id, str):
+            self.request.response.status = 400
+            return {'error': "'id' is required and must be a string"}
+        if not title or not isinstance(title, str):
+            self.request.response.status = 400
+            return {'error': "'title' is required and must be a string"}
+        if icon is not None and not isinstance(icon, str):
+            self.request.response.status = 400
+            return {'error': "'icon' must be a string"}
+
+        root = traversal.find_root(resource=self.context)
+        record = root.get_game_data(user.userid, nodeid, create=True)
+        record.award_badge(badge_id, title, icon)
+        return record.to_dict()
+
+
+@resource(path='/api/v1/achievements', cors_origins=('*',), factory='honeycomb.root_factory')
+class AchievementsResource:
+    """Todos los logros del usuario autenticado, en cualquier nodo (su vitrina)."""
+
+    def __init__(self, request, context=None):
+        self.request = request
+        self.context = context
+
+    def get(self):
+        user = getattr(self.request, 'identity', None)
+        if not user:
+            self.request.response.status = 401
+            return {'error': 'Unauthorized'}
+
+        root = traversal.find_root(resource=self.context)
+        achievements = []
+        for nodeid, badge in root.iter_user_badges(user.userid):
+            entry = badge.to_dict()
+            entry['nodeid'] = nodeid
+            achievements.append(entry)
+        return {'achievements': achievements}
+
+
+@resource(path='/api/v1/share', cors_origins=('*',), factory='honeycomb.root_factory', require_csrf=False)
+class ShareResource:
+    """Publica un logro ya otorgado como una nota en el Fediverso, a nombre del
+    usuario autenticado (via ActivityPub C2S, su propio outbox). Dos formas de
+    fallar que se distinguen en el mensaje: la cuenta nunca vinculo un
+    Fediverso (invita a vincularlo desde /cuenta), o si vinculo pero no hay
+    token utilizable -- honeycomb.token_encryption_key no esta configurada, o
+    hay que volver a iniciar sesion para refrescarlo."""
+
+    def __init__(self, request, context=None):
+        self.request = request
+        self.context = context
+
+    def post(self):
+        user = getattr(self.request, 'identity', None)
+        if not user:
+            self.request.response.status = 401
+            return {'error': 'Unauthorized'}
+
+        try:
+            payload = self.request.json_body
+        except Exception:
+            self.request.response.status = 400
+            return {'error': 'Invalid JSON'}
+        if not isinstance(payload, dict):
+            self.request.response.status = 400
+            return {'error': 'Request body must be a JSON object'}
+
+        nodeid = payload.get('nodeid')
+        badge_id = payload.get('badge_id')
+        if not nodeid or not badge_id:
+            self.request.response.status = 400
+            return {'error': "'nodeid' and 'badge_id' are required"}
+
+        root = traversal.find_root(resource=self.context)
+        record = root.get_game_data(user.userid, nodeid, create=False)
+        badge = next((b for b in (record.badges if record else []) if b.id == badge_id), None)
+        if badge is None:
+            self.request.response.status = 404
+            return {'error': 'Badge not found for this user/node'}
+
+        if not user.has_fediverse_identity():
+            self.request.response.status = 400
+            return {'error': 'Tu cuenta no tiene una identidad del Fediverso vinculada; vinculala desde /cuenta'}
+
+        settings = self.request.registry.settings
+        try:
+            access_token = tokenstore.decrypt_token(settings, user.access_token_encrypted)
+        except tokenstore.TokenStoreError as exc:
+            self.request.response.status = 400
+            return {'error': str(exc)}
+        if not access_token:
+            self.request.response.status = 400
+            return {'error': 'No hay un token de publicacion disponible; vuelve a iniciar sesion'}
+
+        message = payload.get('message') or f'Consegui el logro "{badge.title}" en Convida!'
+        try:
+            activity = activitypub.publish_note(user.outbox, access_token, message)
+        except fediverse.FediverseError as exc:
+            self.request.response.status = 502
+            return {'error': str(exc)}
+
+        return {'status': 'ok', 'activity': activity}

--- a/honeycomb/views/api.py
+++ b/honeycomb/views/api.py
@@ -229,36 +229,90 @@ class UserIDResource:
             'userid': getattr(user, 'userid'),
         }
 
-sipping_data_store = {}
 
-@resource(path='/api/v1/sipping/{nodeid}', cors_origins=('*',))
-class SippingResource:
+@resource(path='/api/v1/me', cors_origins=('*',), factory='honeycomb.root_factory')
+class MeResource:
+    """Datos de solo lectura del usuario autenticado. Contrato homologado (a)."""
+
     def __init__(self, request, context=None):
         self.request = request
         self.context = context
 
     def get(self):
-        nodeid = self.request.matchdict['nodeid']
         user = getattr(self.request, 'identity', None)
-        userid = getattr(user, 'userid', getattr(user, 'id', 'anon'))
-        key = f"{userid}:{nodeid}"
-        data = sipping_data_store.get(key, {
-            'interacciones_previas': [],
-            'estadisticas': {},
-            'logros': []
-        })
-        return data
+        if not user:
+            self.request.response.status = 401
+            return {'error': 'Unauthorized'}
+        return {
+            'userid': user.userid,
+            'displayname': user.display_name,
+            'username': user.username,
+            'icon': user.icon,
+            'background': user.background,
+        }
+
+
+MAX_GAME_PAYLOAD_KEYS = 100
+
+
+def _validate_game_payload(mapping, field_name):
+    if not isinstance(mapping, dict):
+        return f"'{field_name}' must be an object"
+    if len(mapping) > MAX_GAME_PAYLOAD_KEYS:
+        return f"'{field_name}' has too many keys (max {MAX_GAME_PAYLOAD_KEYS})"
+    return None
+
+
+@resource(path='/api/v1/games/{nodeid}/data', cors_origins=('*',), factory='honeycomb.root_factory', require_csrf=False)
+class GameDataResource:
+    """Datos homologados de un videojuego para el usuario autenticado y un nodo (b)."""
+
+    def __init__(self, request, context=None):
+        self.request = request
+        self.context = context
+
+    def get(self):
+        user = getattr(self.request, 'identity', None)
+        if not user:
+            self.request.response.status = 401
+            return {'error': 'Unauthorized'}
+
+        nodeid = self.request.matchdict['nodeid']
+        root = traversal.find_root(resource=self.context)
+        record = root.get_game_data(user.userid, nodeid, create=False)
+        if record is None:
+            return GameData(user.userid, nodeid).to_dict()
+        return record.to_dict()
 
     def post(self):
-        nodeid = self.request.matchdict['nodeid']
         user = getattr(self.request, 'identity', None)
-        userid = getattr(user, 'userid', getattr(user, 'id', 'anon'))
-        key = f"{userid}:{nodeid}"
+        if not user:
+            self.request.response.status = 401
+            return {'error': 'Unauthorized'}
+
+        nodeid = self.request.matchdict['nodeid']
         try:
             payload = self.request.json_body
         except Exception:
             self.request.response.status = 400
             return {'error': 'Invalid JSON'}
-        # Solo permite modificar datos de este nodo
-        sipping_data_store[key] = payload
-        return {'status': 'ok', 'saved': payload}
+        if not isinstance(payload, dict):
+            self.request.response.status = 400
+            return {'error': "Request body must be a JSON object"}
+
+        stats = payload.get('stats', {})
+        preferences = payload.get('preferences', {})
+        replace = bool(payload.get('replace', False))
+
+        error = _validate_game_payload(stats, 'stats') or _validate_game_payload(preferences, 'preferences')
+        if error:
+            self.request.response.status = 400
+            return {'error': error}
+
+        root = traversal.find_root(resource=self.context)
+        record = root.get_game_data(user.userid, nodeid, create=True)
+        # interactions y badges no se aceptan del cliente: los controla el servidor
+        record.merge_stats(stats, replace=replace)
+        record.merge_preferences(preferences, replace=replace)
+        record.register_interaction()
+        return record.to_dict()

--- a/honeycomb/views/api.py
+++ b/honeycomb/views/api.py
@@ -263,9 +263,9 @@ def _validate_game_payload(mapping, field_name):
     return None
 
 
-@resource(path='/api/v1/games/{nodeid}/data', cors_origins=('*',), factory='honeycomb.root_factory', require_csrf=False)
+@resource(path='/api/v1/sipping/{nodeid}', cors_origins=('*',), factory='honeycomb.root_factory', require_csrf=False)
 class GameDataResource:
-    """Datos homologados de un videojuego para el usuario autenticado y un nodo (b)."""
+    """Datos homologados de un videojuego para el usuario autenticado y un nodo (b). Ruta documentada: sipping."""
 
     def __init__(self, request, context=None):
         self.request = request

--- a/honeycomb/views/auth.py
+++ b/honeycomb/views/auth.py
@@ -1,4 +1,8 @@
-from pyramid.csrf import new_csrf_token
+import urllib.parse
+
+from cornice.resource import resource
+from pyramid import traversal
+from pyramid.csrf import new_csrf_token, get_csrf_token
 from pyramid.httpexceptions import HTTPSeeOther, HTTPNotFound
 from pyramid.security import (
     remember,
@@ -15,22 +19,36 @@ from deform import Form, ValidationFailure, Button
 
 from .. import security
 from .. import models
+from ..security import fediverse
+
+
+def _safe_next(raw_next):
+    """Solo permite rutas relativas de un segmento inicial ('/algo'), nunca '//host' ni URLs absolutas."""
+    if not raw_next or not raw_next.startswith('/') or raw_next.startswith('//'):
+        return '/'
+    return raw_next
+
+
+def _denylisted_domains(settings):
+    raw = settings.get('fediverse.denylist', '') or ''
+    return {d.strip().lower() for d in raw.split() if d.strip()}
 
 
 @view_config(name="login", context=models.BeeHive, renderer='templates/login.jinja2')
 @forbidden_view_config(renderer='templates/login.jinja2')
 def login_view(context, request):
-    next_url = request.params.get('next', request.referrer)
-    login_url = '/login'
-    if not next_url or next_url == login_url:
-        next_url = "/"
+    next_url = _safe_next(request.params.get('next', request.referrer))
 
     if request.identity:
         return HTTPSeeOther(location=next_url)
-    else:
-        new_csrf_token(request)
-        headers = remember(request, 'convida@unam.social')
-        return HTTPSeeOther(location=next_url, headers=headers)
+
+    # get_csrf_token reusa el token vigente; new_csrf_token lo invalidaba en cada render.
+    return {
+        'next_url': next_url,
+        'csrf_token': get_csrf_token(request),
+        'error': request.params.get('error'),
+    }
+
 
 @view_config(name='logout', context=models.BeeHive)
 def logout_view(context, request):
@@ -39,3 +57,115 @@ def logout_view(context, request):
     new_csrf_token(request)
     headers = forget(request)
     return HTTPSeeOther(location=next_url, headers=headers)
+
+
+@resource(path='/api/v1/auth/login', cors_origins=('*',), factory='honeycomb.root_factory')
+class FediverseLoginResource:
+    """Inicia el login: resuelve el handle, registra/reusa la app OAuth de esa instancia y redirige a ella."""
+
+    def __init__(self, request, context=None):
+        self.request = request
+        self.context = context
+
+    def post(self):
+        request = self.request
+        handle = request.params.get('handle', '')
+        next_url = _safe_next(request.params.get('next'))
+
+        try:
+            _username, domain = fediverse.parse_handle(handle)
+        except fediverse.FediverseError as exc:
+            return HTTPSeeOther(location=f"/login?error={urllib.parse.quote(str(exc))}")
+
+        if domain in _denylisted_domains(request.registry.settings):
+            error = f"'{domain}' no esta permitido en este servidor"
+            return HTTPSeeOther(location=f"/login?error={urllib.parse.quote(error)}")
+
+        # application_url incluye el prefijo de montaje (p.ej. /backend detras del
+        # reverse proxy), a diferencia de host_url que solo trae scheme+host+puerto.
+        redirect_uri = request.application_url + '/api/v1/auth/callback'
+        root = traversal.find_root(resource=self.context)
+
+        try:
+            oauth_metadata = fediverse.discover_oauth_metadata(domain)
+            scope = fediverse.choose_scope(oauth_metadata)
+
+            cached_app = root.get_oauth_app(domain)
+            if cached_app is None:
+                # dominio nunca visto: confirma que hay un servidor real antes de gastar el registro de app
+                if fediverse.discover_nodeinfo(domain) is None:
+                    raise fediverse.FediverseError(f"No encontramos un servidor del Fediverso en '{domain}'")
+                client_id, client_secret = fediverse.register_app(domain, redirect_uri, scope)
+                root.set_oauth_app(domain, client_id, client_secret)
+            else:
+                client_id, client_secret = cached_app['client_id'], cached_app['client_secret']
+
+            code_verifier = code_challenge = None
+            if fediverse.supports_pkce(oauth_metadata):
+                code_verifier, code_challenge = fediverse.generate_pkce_pair()
+
+            state = fediverse.new_state()
+            authorize_url = fediverse.build_authorize_url(domain, client_id, redirect_uri, state, scope, code_challenge)
+        except fediverse.FediverseError as exc:
+            return HTTPSeeOther(location=f"/login?error={urllib.parse.quote(str(exc))}")
+
+        # client_id/secret tambien viajan en la sesion (de un solo uso, se limpian en el
+        # callback) para que ESTE flujo no dependa de releer la cache de ZODB en el
+        # siguiente request; la cache en ZODB solo acelera logins FUTUROS al mismo dominio.
+        request.session['oauth_state'] = state
+        request.session['oauth_domain'] = domain
+        request.session['oauth_scope'] = scope
+        request.session['oauth_code_verifier'] = code_verifier
+        request.session['oauth_next'] = next_url
+        request.session['oauth_client_id'] = client_id
+        request.session['oauth_client_secret'] = client_secret
+
+        return HTTPSeeOther(location=authorize_url)
+
+
+@resource(path='/api/v1/auth/callback', cors_origins=('*',), factory='honeycomb.root_factory')
+class FediverseCallbackResource:
+    """Completa el login: valida state, intercambia el code, lee el perfil y crea la sesion."""
+
+    def __init__(self, request, context=None):
+        self.request = request
+        self.context = context
+
+    def get(self):
+        request = self.request
+        received_state = request.params.get('state')
+        expected_state = request.session.pop('oauth_state', None)
+        domain = request.session.pop('oauth_domain', None)
+        scope = request.session.pop('oauth_scope', None)
+        code_verifier = request.session.pop('oauth_code_verifier', None)
+        next_url = request.session.pop('oauth_next', None) or '/'
+        client_id = request.session.pop('oauth_client_id', None)
+        client_secret = request.session.pop('oauth_client_secret', None)
+
+        if not fediverse.states_match(expected_state, received_state) or not domain or not client_id:
+            return HTTPSeeOther(location='/login?error=' + urllib.parse.quote('Sesion de login invalida o expirada'))
+
+        code = request.params.get('code')
+        if not code:
+            return HTTPSeeOther(location='/login?error=' + urllib.parse.quote('El login fue cancelado'))
+
+        root = traversal.find_root(resource=self.context)
+        # application_url incluye el prefijo de montaje (p.ej. /backend detras del
+        # reverse proxy), a diferencia de host_url que solo trae scheme+host+puerto.
+        redirect_uri = request.application_url + '/api/v1/auth/callback'
+
+        try:
+            access_token = fediverse.exchange_code(
+                domain, client_id, client_secret,
+                redirect_uri, code, scope, code_verifier,
+            )
+            account = fediverse.fetch_account(domain, access_token)
+        except fediverse.FediverseError as exc:
+            return HTTPSeeOther(location='/login?error=' + urllib.parse.quote(str(exc)))
+
+        drone_user = fediverse.account_to_drone_user(domain, account)
+        root.upsert_user(drone_user)
+
+        new_csrf_token(request)
+        headers = remember(request, drone_user.userid)
+        return HTTPSeeOther(location=_safe_next(next_url), headers=headers)

--- a/honeycomb/views/auth.py
+++ b/honeycomb/views/auth.py
@@ -3,23 +3,16 @@ import urllib.parse
 from cornice.resource import resource
 from pyramid import traversal
 from pyramid.csrf import new_csrf_token, get_csrf_token
-from pyramid.httpexceptions import HTTPSeeOther, HTTPNotFound
-from pyramid.security import (
-    remember,
-    forget,
-    NO_PERMISSION_REQUIRED,
-)
+from pyramid.httpexceptions import HTTPSeeOther
+from pyramid.security import remember, forget
 
 from pyramid.view import (
     forbidden_view_config,
     view_config,
 )
 
-from deform import Form, ValidationFailure, Button
-
-from .. import security
 from .. import models
-from ..security import fediverse
+from ..security import fediverse, tokenstore
 
 
 def _safe_next(raw_next):
@@ -52,8 +45,9 @@ def login_view(context, request):
 
 @view_config(name='logout', context=models.BeeHive)
 def logout_view(context, request):
-    assert request.identity
     next_url = "/"
+    if not request.identity:
+        return HTTPSeeOther(location=next_url)
     new_csrf_token(request)
     headers = forget(request)
     return HTTPSeeOther(location=next_url, headers=headers)
@@ -71,9 +65,12 @@ class FediverseLoginResource:
         request = self.request
         handle = request.params.get('handle', '')
         next_url = _safe_next(request.params.get('next'))
+        # Si ya hay sesion, este login no crea una cuenta nueva: vincula el
+        # Fediverso resuelto a la cuenta actual (ver FediverseCallbackResource).
+        link_to = request.identity.userid if request.identity else None
 
         try:
-            _username, domain = fediverse.parse_handle(handle)
+            username, domain = fediverse.parse_handle(handle)
         except fediverse.FediverseError as exc:
             return HTTPSeeOther(location=f"/login?error={urllib.parse.quote(str(exc))}")
 
@@ -87,15 +84,25 @@ class FediverseLoginResource:
         root = traversal.find_root(resource=self.context)
 
         try:
+            # ActivityPub C2S primero: WebFinger -> Actor -> endpoints que el propio
+            # Actor declare (extension de Mastodon/Pleroma). Si la instancia no los
+            # declara (p.ej. mastodon.social), se cae a las rutas de la API de Mastodon.
+            actor_url = fediverse.discover_actor_url(username, domain)
+            actor = fediverse.fetch_actor(actor_url) if actor_url else None
+            actor_endpoints = fediverse.actor_oauth_endpoints(actor)
+
             oauth_metadata = fediverse.discover_oauth_metadata(domain)
             scope = fediverse.choose_scope(oauth_metadata)
 
             cached_app = root.get_oauth_app(domain)
             if cached_app is None:
-                # dominio nunca visto: confirma que hay un servidor real antes de gastar el registro de app
-                if fediverse.discover_nodeinfo(domain) is None:
+                # Si ya resolvimos el Actor, eso ya confirma que hay un servidor AP real;
+                # si no, confirma con nodeinfo antes de gastar un registro de app.
+                if actor is None and fediverse.discover_nodeinfo(domain) is None:
                     raise fediverse.FediverseError(f"No encontramos un servidor del Fediverso en '{domain}'")
-                client_id, client_secret = fediverse.register_app(domain, redirect_uri, scope)
+                client_id, client_secret = fediverse.register_app(
+                    domain, redirect_uri, scope, endpoint=actor_endpoints.get('registration'),
+                )
                 root.set_oauth_app(domain, client_id, client_secret)
             else:
                 client_id, client_secret = cached_app['client_id'], cached_app['client_secret']
@@ -105,7 +112,10 @@ class FediverseLoginResource:
                 code_verifier, code_challenge = fediverse.generate_pkce_pair()
 
             state = fediverse.new_state()
-            authorize_url = fediverse.build_authorize_url(domain, client_id, redirect_uri, state, scope, code_challenge)
+            authorize_url = fediverse.build_authorize_url(
+                domain, client_id, redirect_uri, state, scope, code_challenge,
+                endpoint=actor_endpoints.get('authorization'),
+            )
         except fediverse.FediverseError as exc:
             return HTTPSeeOther(location=f"/login?error={urllib.parse.quote(str(exc))}")
 
@@ -119,6 +129,9 @@ class FediverseLoginResource:
         request.session['oauth_next'] = next_url
         request.session['oauth_client_id'] = client_id
         request.session['oauth_client_secret'] = client_secret
+        request.session['oauth_token_endpoint'] = actor_endpoints.get('token')
+        request.session['oauth_actor'] = actor
+        request.session['oauth_link_to'] = link_to
 
         return HTTPSeeOther(location=authorize_url)
 
@@ -141,6 +154,9 @@ class FediverseCallbackResource:
         next_url = request.session.pop('oauth_next', None) or '/'
         client_id = request.session.pop('oauth_client_id', None)
         client_secret = request.session.pop('oauth_client_secret', None)
+        token_endpoint = request.session.pop('oauth_token_endpoint', None)
+        actor = request.session.pop('oauth_actor', None)
+        link_to = request.session.pop('oauth_link_to', None)
 
         if not fediverse.states_match(expected_state, received_state) or not domain or not client_id:
             return HTTPSeeOther(location='/login?error=' + urllib.parse.quote('Sesion de login invalida o expirada'))
@@ -158,14 +174,62 @@ class FediverseCallbackResource:
             access_token = fediverse.exchange_code(
                 domain, client_id, client_secret,
                 redirect_uri, code, scope, code_verifier,
+                endpoint=token_endpoint,
             )
-            account = fediverse.fetch_account(domain, access_token)
+            # El Actor ya resuelto por WebFinger (antes de la aprobacion) es la fuente
+            # primaria del perfil; verify_credentials solo si no trajo un `id` usable.
+            if actor and actor.get('id'):
+                drone_user = fediverse.actor_to_drone_user(domain, actor)
+            else:
+                account = fediverse.fetch_account(domain, access_token)
+                drone_user = fediverse.account_to_drone_user(domain, account)
+
+            if link_to is not None and root.get_user(link_to) is None:
+                raise fediverse.FediverseError('Tu sesion expiro, intenta vincular de nuevo')
+
+            existing_link = root.resolve_identity(f'fediverse:{drone_user.userid}')
+            if link_to is not None and existing_link is not None and existing_link != link_to:
+                raise fediverse.FediverseError('Esa cuenta del Fediverso ya esta vinculada a otra cuenta de Honeycomb')
         except fediverse.FediverseError as exc:
             return HTTPSeeOther(location='/login?error=' + urllib.parse.quote(str(exc)))
 
-        drone_user = fediverse.account_to_drone_user(domain, account)
-        root.upsert_user(drone_user)
+        # Sin honeycomb.token_encryption_key configurada, encrypt_token regresa None:
+        # el token nunca se guarda en claro, y publicar al Fediverso queda deshabilitado
+        # hasta que el administrador de la instancia provea una clave.
+        encrypted_token = tokenstore.encrypt_token(request.registry.settings, access_token)
+
+        # userid primario de la cuenta: el que ya tenia esta credencial vinculada
+        # (si la vinculacion ya existia), o al que se esta vinculando ahora, o el
+        # propio del Actor si es la primera vez que se ve (login normal, sin
+        # vinculacion -- el caso de siempre, cero migracion para cuentas viejas).
+        primary_userid = link_to or existing_link or drone_user.userid
+        identity_key = f'fediverse:{drone_user.userid}'
+
+        existing = root.get_user(primary_userid)
+        if existing is None:
+            drone_user.userid = primary_userid
+            drone_user.access_token_encrypted = encrypted_token
+            root.upsert_user(drone_user)
+        else:
+            # Nunca reemplazar al usuario existente entero: perderia password_hash
+            # u otras credenciales ya vinculadas (ver update_profile en users.py).
+            existing.update_profile(
+                display_name=drone_user.display_name, username=drone_user.username,
+                icon=drone_user.icon, background=drone_user.background,
+                actor_url=drone_user.actor_url, inbox=drone_user.inbox, outbox=drone_user.outbox,
+            )
+            existing.access_token_encrypted = encrypted_token
+
+        root.link_identity(identity_key, primary_userid)
+        if link_to is not None and existing_link is None:
+            # Primera vez que se vincula este Actor: si ya tenia progreso propio
+            # (jugo antes de vincular), se funde con el de la cuenta primaria.
+            root.merge_game_data(drone_user.userid, primary_userid)
 
         new_csrf_token(request)
-        headers = remember(request, drone_user.userid)
+        if link_to is not None:
+            # Ya habia sesion iniciada como link_to; no hace falta remember() de
+            # nuevo, el principal de la cookie no cambia.
+            return HTTPSeeOther(location=_safe_next(next_url))
+        headers = remember(request, primary_userid)
         return HTTPSeeOther(location=_safe_next(next_url), headers=headers)

--- a/honeycomb/views/local_auth.py
+++ b/honeycomb/views/local_auth.py
@@ -1,0 +1,149 @@
+import urllib.parse
+
+from cornice.resource import resource
+from pyramid import traversal
+from pyramid.csrf import new_csrf_token, get_csrf_token
+from pyramid.httpexceptions import HTTPSeeOther
+from pyramid.security import remember
+from pyramid.view import view_config
+
+from .. import models
+from ..security import local_accounts
+from .auth import _safe_next
+
+
+@view_config(name='register', context=models.BeeHive, renderer='templates/register.jinja2')
+def register_view(context, request):
+    next_url = _safe_next(request.params.get('next', request.referrer))
+
+    if request.identity:
+        return HTTPSeeOther(location=next_url)
+
+    return {
+        'next_url': next_url,
+        'csrf_token': get_csrf_token(request),
+        'error': request.params.get('error'),
+        'enabled': local_accounts.is_enabled(request.registry.settings),
+    }
+
+
+@view_config(name='cuenta', context=models.BeeHive, renderer='templates/cuenta.jinja2')
+def account_view(context, request):
+    """Muestra las credenciales vinculadas a la cuenta y permite vincular o
+    desvincular. Es donde el encargo de dejar la separacion de identidades
+    visible (no solo documentada) se hace concreto en la interfaz."""
+    if not request.identity:
+        return HTTPSeeOther(location='/login?next=' + urllib.parse.quote('/cuenta'))
+
+    root = traversal.find_root(resource=context)
+    identities = sorted(root.iter_identities(request.identity.userid))
+    return {
+        'identities': identities,
+        'has_password': bool(request.identity.password_hash),
+        'error': request.params.get('error'),
+        'csrf_token': get_csrf_token(request),
+        'local_accounts_enabled': local_accounts.is_enabled(request.registry.settings),
+    }
+
+
+@resource(path='/api/v1/auth/register', cors_origins=('*',), factory='honeycomb.root_factory')
+class RegisterResource:
+    """Registro abierto de una cuenta local nueva (usuario + contrasena)."""
+
+    def __init__(self, request, context=None):
+        self.request = request
+        self.context = context
+
+    def post(self):
+        request = self.request
+        next_url = _safe_next(request.params.get('next'))
+        root = traversal.find_root(resource=self.context)
+
+        try:
+            user = local_accounts.register(
+                root, request.registry.settings,
+                request.params.get('username', ''), request.params.get('password', ''),
+            )
+        except local_accounts.LocalAuthError as exc:
+            return HTTPSeeOther(location=f"/register?error={urllib.parse.quote(str(exc))}")
+
+        new_csrf_token(request)
+        headers = remember(request, user.userid)
+        return HTTPSeeOther(location=next_url, headers=headers)
+
+
+@resource(path='/api/v1/auth/local', cors_origins=('*',), factory='honeycomb.root_factory')
+class LocalLoginResource:
+    """Login con una cuenta local ya existente."""
+
+    def __init__(self, request, context=None):
+        self.request = request
+        self.context = context
+
+    def post(self):
+        request = self.request
+        next_url = _safe_next(request.params.get('next'))
+        root = traversal.find_root(resource=self.context)
+
+        try:
+            user = local_accounts.authenticate(
+                root, request.registry.settings,
+                request.params.get('username', ''), request.params.get('password', ''),
+            )
+        except local_accounts.LocalAuthError as exc:
+            return HTTPSeeOther(location=f"/login?error={urllib.parse.quote(str(exc))}")
+
+        new_csrf_token(request)
+        headers = remember(request, user.userid)
+        return HTTPSeeOther(location=next_url, headers=headers)
+
+
+@resource(path='/api/v1/auth/link/password', cors_origins=('*',), factory='honeycomb.root_factory')
+class LinkPasswordResource:
+    """Le agrega una credencial de contrasena a la cuenta ya autenticada."""
+
+    def __init__(self, request, context=None):
+        self.request = request
+        self.context = context
+
+    def post(self):
+        request = self.request
+        if not request.identity:
+            request.response.status = 401
+            return {'error': 'Unauthorized'}
+
+        root = traversal.find_root(resource=self.context)
+        try:
+            local_accounts.link_password(
+                root, request.registry.settings, request.identity,
+                request.params.get('username', ''), request.params.get('password', ''),
+            )
+        except local_accounts.LocalAuthError as exc:
+            return HTTPSeeOther(location=f"/cuenta?error={urllib.parse.quote(str(exc))}")
+
+        new_csrf_token(request)
+        return HTTPSeeOther(location='/cuenta')
+
+
+@resource(path='/api/v1/auth/unlink', cors_origins=('*',), factory='honeycomb.root_factory')
+class UnlinkResource:
+    """Quita una credencial de la cuenta autenticada. Se niega a quitar la ultima."""
+
+    def __init__(self, request, context=None):
+        self.request = request
+        self.context = context
+
+    def post(self):
+        request = self.request
+        if not request.identity:
+            request.response.status = 401
+            return {'error': 'Unauthorized'}
+
+        root = traversal.find_root(resource=self.context)
+        try:
+            local_accounts.unlink(root, request.identity.userid, request.params.get('identity_key', ''))
+        except local_accounts.LocalAuthError as exc:
+            return HTTPSeeOther(location=f"/cuenta?error={urllib.parse.quote(str(exc))}")
+
+        new_csrf_token(request)
+        return HTTPSeeOther(location='/cuenta')

--- a/honeycomb/views/openapi.py
+++ b/honeycomb/views/openapi.py
@@ -1,0 +1,12 @@
+from cornice.resource import resource
+
+from ..openapi import build_openapi_spec
+
+
+@resource(path='/openapi/openapi.json', cors_origins=('*',))
+class OpenAPISpecResource:
+    def __init__(self, request, context=None):
+        self.request = request
+
+    def get(self):
+        return build_openapi_spec(self.request.application_url)

--- a/production.ini
+++ b/production.ini
@@ -19,6 +19,10 @@ retry.attempts = 3
 # Enable only when the app is running behind a reverse proxy.
 honeycomb.use_proxy_headers = true
 
+# Dominios del Fediverso a los que nunca se les registra una app OAuth ni se
+# les redirige, separados por espacios. Vacio = nada bloqueado por default.
+fediverse.denylist =
+
 [pshell]
 setup = honeycomb.pshell.setup
 

--- a/production.ini
+++ b/production.ini
@@ -16,12 +16,40 @@ zodbconn.uri = file://%(here)s/Data.fs?connection_cache_size=20000
 
 retry.attempts = 3
 
+# Este valor debe establecerlo quien administre la instancia de la plataforma,
+# por lo que deberia quedarse vacio aqui. Sin un valor real, el servidor no
+# arranca (assert explicito) en vez de firmar cookies con un secreto conocido.
+auth.secret =
+
 # Enable only when the app is running behind a reverse proxy.
 honeycomb.use_proxy_headers = true
 
 # Dominios del Fediverso a los que nunca se les registra una app OAuth ni se
 # les redirige, separados por espacios. Vacio = nada bloqueado por default.
 fediverse.denylist =
+
+# Limites configurables por quien administra la instancia. Vacio/0 = sin limite.
+honeycomb.max_game_payload_keys =
+fediverse.registration_rate_window_seconds =
+fediverse.registration_rate_max_per_domain =
+fediverse.registration_rate_max_global =
+
+# Clave Fernet para cifrar en reposo el access_token OAuth del Fediverso. Vacio
+# = el token nunca se guarda y publicar logros queda deshabilitado. Generar con:
+#   uv run python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+honeycomb.token_encryption_key =
+
+# Cuentas locales (usuario + contrasena), alternativa a entrar por el
+# Fediverso, con registro abierto. Vacio = deshabilitadas: las activa quien
+# administra la instancia. Sin correo en el proyecto no hay verificacion de
+# cuenta ni recuperacion de contrasena -- quien la pierde pierde esa
+# credencial (puede seguir entrando por cualquier otra que tenga vinculada).
+honeycomb.local_accounts =
+honeycomb.min_password_length =
+honeycomb.login_rate_window_seconds =
+honeycomb.login_rate_max_per_user =
+honeycomb.login_rate_max_global =
+honeycomb.registration_rate_max_global =
 
 [pshell]
 setup = honeycomb.pshell.setup

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "pyramid-storage>=1.3.2",
     "pyramid-tm>=2.6",
     "pyramid-zodbconn>=0.8.1",
+    "requests>=2.31.0",
     "scipy>=1.16.3",
     "transaction>=5.0",
     "waitress>=3.0.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "cornice>=6.1.0",
+    "cryptography>=42.0.0",
     "deform>=2.0.15",
     "numpy>=2.3.5",
     "plaster-pastedeploy>=1.0.1",

--- a/testing.ini
+++ b/testing.ini
@@ -16,6 +16,8 @@ zodbconn.uri = file://%(here)s/Data.testing.fs?connection_cache_size=20000
 
 retry.attempts = 3
 
+auth.secret = testing-only-insecure-secret
+
 [pshell]
 setup = honeycomb.pshell.setup
 

--- a/testing.ini
+++ b/testing.ini
@@ -20,6 +20,24 @@ auth.secret = testing-only-insecure-secret
 
 fediverse.denylist =
 
+honeycomb.max_game_payload_keys =
+fediverse.registration_rate_window_seconds =
+fediverse.registration_rate_max_per_domain =
+fediverse.registration_rate_max_global =
+
+# Clave de pruebas fija (no usar en produccion) para que la suite pueda
+# ejercitar el cifrado real del access_token, no solo el caso "sin clave".
+honeycomb.token_encryption_key = 4-WcTaoFuXoKi8Ci2dL3Gihpn-xZRfZ4fmLQpg4fT5g=
+
+# Encendidas por default para que la suite ejercite el camino real; los tests
+# que necesitan probar el caso deshabilitado lo apagan con monkeypatch.setitem.
+honeycomb.local_accounts = true
+honeycomb.min_password_length =
+honeycomb.login_rate_window_seconds =
+honeycomb.login_rate_max_per_user =
+honeycomb.login_rate_max_global =
+honeycomb.registration_rate_max_global =
+
 [pshell]
 setup = honeycomb.pshell.setup
 

--- a/testing.ini
+++ b/testing.ini
@@ -18,6 +18,8 @@ retry.attempts = 3
 
 auth.secret = testing-only-insecure-secret
 
+fediverse.denylist =
+
 [pshell]
 setup = honeycomb.pshell.setup
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,19 @@ FAKE_FEDIVERSE_ACCOUNT = {
     'avatar': 'https://fake.fediverse.test/avatar.png',
     'header': 'https://fake.fediverse.test/header.png',
 }
+# Actor AS2 sin endpoints.oauth* -- ejercita el fallback a las rutas de la API de
+# Mastodon, igual que mastodon.social en la verificacion en vivo.
+FAKE_ACTOR = {
+    'id': 'https://fake.fediverse.test/users/tester',
+    'type': 'Person',
+    'preferredUsername': 'tester',
+    'name': 'Test User',
+    'icon': {'url': 'https://fake.fediverse.test/avatar.png'},
+    'image': {'url': 'https://fake.fediverse.test/header.png'},
+    'inbox': 'https://fake.fediverse.test/users/tester/inbox',
+    'outbox': 'https://fake.fediverse.test/users/tester/outbox',
+    'endpoints': {},
+}
 
 
 def pytest_addoption(parser):
@@ -91,21 +104,81 @@ def dummy_request(tm):
     return request
 
 @pytest.fixture
-def fediverse_stub(monkeypatch):
-    """Monkeypatches el modulo fediverse con una instancia fake bien portada, sin red real.
+def identity_bridge(monkeypatch):
+    """Puentea BeeHive.get_user/upsert_user/resolve_identity/link_identity/
+    unlink_identity/iter_identities por fuera de ZODB: el fixture testapp aborta
+    cada request en su propia transaccion (ver nota en
+    docs/comunicacion-videojuegos-api.md), asi que sin este puente una cuenta
+    creada en un request no existiria todavia para el siguiente. Compartido por
+    cualquier flujo de mas de un request, sea login por Fediverso, registro
+    local, o vincular ambos. Es solo para pruebas; el codigo de produccion
+    sigue usando ZODB en todo momento.
+    """
+    from honeycomb.models.beehive import BeeHive
 
-    Tambien puentea BeeHive.upsert_user/SecurityPolicy.load_identity por fuera de ZODB:
-    el fixture testapp aborta cada request en su propia transaccion (ver nota en
-    docs/comunicacion-videojuegos-api.md), asi que sin este puente un usuario logueado
-    en un request no existiria todavia para el siguiente. Es solo para pruebas; el
-    codigo de produccion sigue usando ZODB en todo momento.
+    users = {}
+    identities = {}
+
+    original_upsert_user = BeeHive.upsert_user
+
+    def patched_upsert_user(self, drone_user):
+        users[drone_user.userid] = drone_user
+        return original_upsert_user(self, drone_user)
+
+    original_get_user = BeeHive.get_user
+
+    def patched_get_user(self, userid):
+        if userid in users:
+            return users[userid]
+        return original_get_user(self, userid)
+
+    original_resolve_identity = BeeHive.resolve_identity
+
+    def patched_resolve_identity(self, key):
+        if key in identities:
+            return identities[key]
+        return original_resolve_identity(self, key)
+
+    original_link_identity = BeeHive.link_identity
+
+    def patched_link_identity(self, key, userid):
+        identities[key] = userid
+        return original_link_identity(self, key, userid)
+
+    original_unlink_identity = BeeHive.unlink_identity
+
+    def patched_unlink_identity(self, key):
+        identities.pop(key, None)
+        return original_unlink_identity(self, key)
+
+    def patched_iter_identities(self, userid):
+        for key, linked_userid in identities.items():
+            if linked_userid == userid:
+                yield key
+
+    monkeypatch.setattr(BeeHive, 'upsert_user', patched_upsert_user)
+    monkeypatch.setattr(BeeHive, 'get_user', patched_get_user)
+    monkeypatch.setattr(BeeHive, 'resolve_identity', patched_resolve_identity)
+    monkeypatch.setattr(BeeHive, 'link_identity', patched_link_identity)
+    monkeypatch.setattr(BeeHive, 'unlink_identity', patched_unlink_identity)
+    monkeypatch.setattr(BeeHive, 'iter_identities', patched_iter_identities)
+
+    return {'users': users, 'identities': identities}
+
+
+@pytest.fixture
+def fediverse_stub(monkeypatch, identity_bridge):
+    """Monkeypatches el modulo fediverse con una instancia fake bien portada, sin
+    red real. La persistencia entre requests la da identity_bridge; aqui solo se
+    puentea lo especifico del OAuth del Fediverso (set_oauth_app/get_oauth_app).
     """
     from honeycomb.models.beehive import BeeHive
     from honeycomb.security import fediverse
 
-    test_users = {}
     test_oauth_apps = {}
 
+    monkeypatch.setattr(fediverse, 'discover_actor_url', lambda username, domain: FAKE_ACTOR['id'])
+    monkeypatch.setattr(fediverse, 'fetch_actor', lambda actor_url: dict(FAKE_ACTOR))
     monkeypatch.setattr(fediverse, 'discover_nodeinfo', lambda domain: {'software': {'name': 'testodon'}})
     monkeypatch.setattr(fediverse, 'discover_oauth_metadata', lambda domain: {
         'scopes_supported': ['read:accounts'],
@@ -113,26 +186,13 @@ def fediverse_stub(monkeypatch):
     })
     monkeypatch.setattr(
         fediverse, 'register_app',
-        lambda domain, redirect_uri, scope, client_name='Honeycomb': ('fake-client-id', 'fake-client-secret'),
+        lambda domain, redirect_uri, scope, client_name='Honeycomb', endpoint=None: ('fake-client-id', 'fake-client-secret'),
     )
     monkeypatch.setattr(
         fediverse, 'exchange_code',
-        lambda domain, client_id, client_secret, redirect_uri, code, scope, code_verifier=None: 'fake-access-token',
+        lambda domain, client_id, client_secret, redirect_uri, code, scope, code_verifier=None, endpoint=None: 'fake-access-token',
     )
     monkeypatch.setattr(fediverse, 'fetch_account', lambda domain, access_token: dict(FAKE_FEDIVERSE_ACCOUNT))
-
-    original_upsert_user = BeeHive.upsert_user
-
-    def patched_upsert_user(self, drone_user):
-        test_users[drone_user.userid] = drone_user
-        return original_upsert_user(self, drone_user)
-
-    original_get_user = BeeHive.get_user
-
-    def patched_get_user(self, userid):
-        if userid in test_users:
-            return test_users[userid]
-        return original_get_user(self, userid)
 
     original_set_oauth_app = BeeHive.set_oauth_app
 
@@ -148,8 +208,6 @@ def fediverse_stub(monkeypatch):
             return test_oauth_apps[domain]
         return original_get_oauth_app(self, domain)
 
-    monkeypatch.setattr(BeeHive, 'upsert_user', patched_upsert_user)
-    monkeypatch.setattr(BeeHive, 'get_user', patched_get_user)
     monkeypatch.setattr(BeeHive, 'set_oauth_app', patched_set_oauth_app)
     monkeypatch.setattr(BeeHive, 'get_oauth_app', patched_get_oauth_app)
 
@@ -157,6 +215,10 @@ def fediverse_stub(monkeypatch):
         'domain': FAKE_FEDIVERSE_DOMAIN,
         'userid': FAKE_FEDIVERSE_ACCOUNT['uri'],
         'handle': f"tester@{FAKE_FEDIVERSE_DOMAIN}",
+        # Puente directo al DroneUser persistido (ver identity_bridge); util para
+        # que los tests inspeccionen campos que no se exponen via API (p.ej. el
+        # token cifrado) sin tener que abrir una ruta de depuracion insegura.
+        'get_stored_user': lambda: identity_bridge['users'].get(FAKE_FEDIVERSE_ACCOUNT['uri']),
     }
 
 
@@ -165,7 +227,7 @@ def login_as_fediverse_user(testapp, fediverse_stub):
     """Corre el flujo real de login (POST /api/v1/auth/login -> GET /api/v1/auth/callback) contra la instancia fake."""
     def _login(next_url='/'):
         login_page = testapp.get('/login', status=200)
-        csrf_token = login_page.form['csrf_token'].value
+        csrf_token = login_page.forms['fediverse-login-form']['csrf_token'].value
         start_resp = testapp.post('/api/v1/auth/login', {
             'handle': fediverse_stub['handle'],
             'csrf_token': csrf_token,
@@ -176,6 +238,76 @@ def login_as_fediverse_user(testapp, fediverse_stub):
         testapp.get('/api/v1/auth/callback', {'code': 'fake-code', 'state': state}, status=303)
         return fediverse_stub
     return _login
+
+
+@pytest.fixture
+def register_as_local_user(testapp, identity_bridge):
+    """Corre el registro real (GET /register -> POST /api/v1/auth/register) y deja
+    la sesion autenticada como esa cuenta nueva."""
+    def _register(username='alice', password='correct horse battery staple', next_url='/'):
+        page = testapp.get('/register', status=200)
+        csrf_token = page.forms['register-form']['csrf_token'].value
+        testapp.post('/api/v1/auth/register', {
+            'username': username, 'password': password, 'csrf_token': csrf_token, 'next': next_url,
+        }, status=303)
+        return {'username': username, 'password': password}
+    return _register
+
+
+@pytest.fixture
+def login_as_local_user(testapp):
+    """Corre el login local real (GET /login -> POST /api/v1/auth/local)."""
+    def _login(username, password, next_url='/'):
+        page = testapp.get('/login', status=200)
+        csrf_token = page.forms['local-login-form']['csrf_token'].value
+        return testapp.post('/api/v1/auth/local', {
+            'username': username, 'password': password, 'csrf_token': csrf_token, 'next': next_url,
+        }, status=303)
+    return _login
+
+
+@pytest.fixture
+def game_data_bridge(monkeypatch):
+    """Puentea BeeHive.get_game_data/merge_game_data por fuera de ZODB, igual que
+    identity_bridge hace con los usuarios: necesario para probar flujos que
+    abarcan mas de un request (otorgar un logro y despues compartirlo, o jugar
+    y despues vincular la cuenta a otra)."""
+    from honeycomb.models.beehive import BeeHive
+
+    store = {}
+    original_get_game_data = BeeHive.get_game_data
+    original_merge_game_data = BeeHive.merge_game_data
+
+    def patched_get_game_data(self, userid, nodeid, create=False):
+        key = (userid, nodeid)
+        if key in store:
+            return store[key]
+        if not create:
+            return None
+        record = original_get_game_data(self, userid, nodeid, create=True)
+        store[key] = record
+        return record
+
+    class _FakeGameDataHost:
+        def __init__(self, buckets):
+            self.__game_data__ = buckets
+
+    def patched_merge_game_data(self, from_userid, into_userid):
+        # Reusa la logica real de fusion operando sobre un host de mentiras cuyo
+        # __game_data__ refleja el store del bridge, y despues aplana el
+        # resultado de vuelta -- asi la regla de fusion no se duplica aqui.
+        buckets = {}
+        for (userid, nodeid), record in store.items():
+            buckets.setdefault(userid, {})[nodeid] = record
+        original_merge_game_data(_FakeGameDataHost(buckets), from_userid, into_userid)
+        store.clear()
+        for userid, bucket in buckets.items():
+            for nodeid, record in bucket.items():
+                store[(userid, nodeid)] = record
+
+    monkeypatch.setattr(BeeHive, 'get_game_data', patched_get_game_data)
+    monkeypatch.setattr(BeeHive, 'merge_game_data', patched_merge_game_data)
+    return store
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+import urllib.parse
 from pyramid.paster import get_appsettings
 from pyramid.scripting import prepare
 from pyramid.testing import DummyRequest, testConfig
@@ -7,6 +8,17 @@ import transaction
 import webtest
 
 from honeycomb import main
+
+FAKE_FEDIVERSE_DOMAIN = 'fake.fediverse.test'
+FAKE_FEDIVERSE_ACCOUNT = {
+    'id': '1',
+    'uri': 'https://fake.fediverse.test/users/tester',
+    'username': 'tester',
+    'acct': 'tester',
+    'display_name': 'Test User',
+    'avatar': 'https://fake.fediverse.test/avatar.png',
+    'header': 'https://fake.fediverse.test/header.png',
+}
 
 
 def pytest_addoption(parser):
@@ -77,6 +89,94 @@ def dummy_request(tm):
     request.tm = tm
 
     return request
+
+@pytest.fixture
+def fediverse_stub(monkeypatch):
+    """Monkeypatches el modulo fediverse con una instancia fake bien portada, sin red real.
+
+    Tambien puentea BeeHive.upsert_user/SecurityPolicy.load_identity por fuera de ZODB:
+    el fixture testapp aborta cada request en su propia transaccion (ver nota en
+    docs/comunicacion-videojuegos-api.md), asi que sin este puente un usuario logueado
+    en un request no existiria todavia para el siguiente. Es solo para pruebas; el
+    codigo de produccion sigue usando ZODB en todo momento.
+    """
+    from honeycomb.models.beehive import BeeHive
+    from honeycomb.security import fediverse
+
+    test_users = {}
+    test_oauth_apps = {}
+
+    monkeypatch.setattr(fediverse, 'discover_nodeinfo', lambda domain: {'software': {'name': 'testodon'}})
+    monkeypatch.setattr(fediverse, 'discover_oauth_metadata', lambda domain: {
+        'scopes_supported': ['read:accounts'],
+        'code_challenge_methods_supported': ['S256'],
+    })
+    monkeypatch.setattr(
+        fediverse, 'register_app',
+        lambda domain, redirect_uri, scope, client_name='Honeycomb': ('fake-client-id', 'fake-client-secret'),
+    )
+    monkeypatch.setattr(
+        fediverse, 'exchange_code',
+        lambda domain, client_id, client_secret, redirect_uri, code, scope, code_verifier=None: 'fake-access-token',
+    )
+    monkeypatch.setattr(fediverse, 'fetch_account', lambda domain, access_token: dict(FAKE_FEDIVERSE_ACCOUNT))
+
+    original_upsert_user = BeeHive.upsert_user
+
+    def patched_upsert_user(self, drone_user):
+        test_users[drone_user.userid] = drone_user
+        return original_upsert_user(self, drone_user)
+
+    original_get_user = BeeHive.get_user
+
+    def patched_get_user(self, userid):
+        if userid in test_users:
+            return test_users[userid]
+        return original_get_user(self, userid)
+
+    original_set_oauth_app = BeeHive.set_oauth_app
+
+    def patched_set_oauth_app(self, domain, client_id, client_secret):
+        result = original_set_oauth_app(self, domain, client_id, client_secret)
+        test_oauth_apps[domain] = result
+        return result
+
+    original_get_oauth_app = BeeHive.get_oauth_app
+
+    def patched_get_oauth_app(self, domain):
+        if domain in test_oauth_apps:
+            return test_oauth_apps[domain]
+        return original_get_oauth_app(self, domain)
+
+    monkeypatch.setattr(BeeHive, 'upsert_user', patched_upsert_user)
+    monkeypatch.setattr(BeeHive, 'get_user', patched_get_user)
+    monkeypatch.setattr(BeeHive, 'set_oauth_app', patched_set_oauth_app)
+    monkeypatch.setattr(BeeHive, 'get_oauth_app', patched_get_oauth_app)
+
+    return {
+        'domain': FAKE_FEDIVERSE_DOMAIN,
+        'userid': FAKE_FEDIVERSE_ACCOUNT['uri'],
+        'handle': f"tester@{FAKE_FEDIVERSE_DOMAIN}",
+    }
+
+
+@pytest.fixture
+def login_as_fediverse_user(testapp, fediverse_stub):
+    """Corre el flujo real de login (POST /api/v1/auth/login -> GET /api/v1/auth/callback) contra la instancia fake."""
+    def _login(next_url='/'):
+        login_page = testapp.get('/login', status=200)
+        csrf_token = login_page.form['csrf_token'].value
+        start_resp = testapp.post('/api/v1/auth/login', {
+            'handle': fediverse_stub['handle'],
+            'csrf_token': csrf_token,
+            'next': next_url,
+        }, status=303)
+        authorize_url = start_resp.headers['Location']
+        state = urllib.parse.parse_qs(urllib.parse.urlsplit(authorize_url).query)['state'][0]
+        testapp.get('/api/v1/auth/callback', {'code': 'fake-code', 'state': state}, status=303)
+        return fediverse_stub
+    return _login
+
 
 @pytest.fixture
 def dummy_config(dummy_request):

--- a/tests/test_activitypub.py
+++ b/tests/test_activitypub.py
@@ -1,0 +1,144 @@
+import pytest
+
+from honeycomb.security import activitypub, fediverse
+
+
+class _FakeJSONResponse:
+    def __init__(self, status_code, payload):
+        self.status_code = status_code
+        self._payload = payload
+        self.is_redirect = False
+        self.is_permanent_redirect = False
+
+    def json(self):
+        return self._payload
+
+
+def _stub_request(monkeypatch, response):
+    captured = {}
+
+    def fake_request(method, url, **kwargs):
+        captured['method'] = method
+        captured['url'] = url
+        captured['kwargs'] = kwargs
+        return response
+
+    monkeypatch.setattr(fediverse.requests, 'request', fake_request)
+    monkeypatch.setattr(fediverse, '_assert_public_host', lambda host: None)
+    return captured
+
+
+OUTBOX = 'https://example.social/users/tester/outbox'
+
+
+def test_publish_note_sends_authenticated_create_request(monkeypatch):
+    captured = _stub_request(monkeypatch, _FakeJSONResponse(201, {'id': 'https://example.social/activities/1'}))
+    result = activitypub.publish_note(OUTBOX, 'tok123', 'Logre algo!')
+    assert captured['method'] == 'POST'
+    assert captured['url'] == OUTBOX
+    assert captured['kwargs']['headers']['Authorization'] == 'Bearer tok123'
+    assert captured['kwargs']['headers']['Content-Type'] == activitypub.C2S_CONTENT_TYPE
+    note = captured['kwargs']['json']
+    assert note['type'] == 'Note'
+    assert note['content'] == 'Logre algo!'
+    assert note['to'] == ['https://www.w3.org/ns/activitystreams#Public']
+    assert result == {'id': 'https://example.social/activities/1'}
+
+
+def test_publish_note_not_public_omits_to_field(monkeypatch):
+    captured = _stub_request(monkeypatch, _FakeJSONResponse(201, {}))
+    activitypub.publish_note(OUTBOX, 'tok123', 'privado', to_public=False)
+    assert 'to' not in captured['kwargs']['json']
+
+
+def test_publish_note_requires_outbox_url():
+    with pytest.raises(fediverse.FediverseError):
+        activitypub.publish_note(None, 'tok123', 'hola')
+
+
+def test_publish_note_requires_access_token():
+    with pytest.raises(fediverse.FediverseError):
+        activitypub.publish_note(OUTBOX, None, 'hola')
+
+
+def test_publish_note_raises_on_error_status(monkeypatch):
+    _stub_request(monkeypatch, _FakeJSONResponse(403, {'error': 'forbidden'}))
+    with pytest.raises(fediverse.FediverseError):
+        activitypub.publish_note(OUTBOX, 'tok123', 'hola')
+
+
+def test_publish_note_raises_on_network_error(monkeypatch):
+    def fail(*a, **k):
+        raise fediverse.requests.RequestException('boom')
+    monkeypatch.setattr(fediverse.requests, 'request', fail)
+    monkeypatch.setattr(fediverse, '_assert_public_host', lambda host: None)
+    with pytest.raises(fediverse.FediverseError):
+        activitypub.publish_note(OUTBOX, 'tok123', 'hola')
+
+
+def test_read_outbox_returns_collection_with_direct_items(monkeypatch):
+    collection = {'type': 'OrderedCollection', 'orderedItems': [{'type': 'Note', 'content': 'hola'}]}
+    captured = _stub_request(monkeypatch, _FakeJSONResponse(200, collection))
+    result = activitypub.read_outbox(OUTBOX)
+    assert result == collection
+    assert captured['url'] == OUTBOX
+    assert 'Authorization' not in captured['kwargs']['headers']
+
+
+def test_read_outbox_includes_bearer_when_token_given(monkeypatch):
+    _stub_request(monkeypatch, _FakeJSONResponse(200, {'orderedItems': []}))
+    activitypub.read_outbox(OUTBOX, access_token='tok123')
+
+
+def test_read_outbox_follows_first_page_when_summary_only(monkeypatch):
+    first_page_url = OUTBOX + '?page=true'
+    responses = {
+        OUTBOX: _FakeJSONResponse(200, {'type': 'OrderedCollection', 'first': first_page_url}),
+        first_page_url: _FakeJSONResponse(200, {'type': 'OrderedCollectionPage', 'orderedItems': [{'content': 'hi'}]}),
+    }
+
+    def fake_request(method, url, **kwargs):
+        return responses[url]
+
+    monkeypatch.setattr(fediverse.requests, 'request', fake_request)
+    monkeypatch.setattr(fediverse, '_assert_public_host', lambda host: None)
+
+    result = activitypub.read_outbox(OUTBOX)
+    assert result['orderedItems'] == [{'content': 'hi'}]
+
+
+def test_read_outbox_follows_first_page_given_as_object_with_id(monkeypatch):
+    first_page_url = OUTBOX + '?page=true'
+    responses = {
+        OUTBOX: _FakeJSONResponse(200, {'first': {'id': first_page_url}}),
+        first_page_url: _FakeJSONResponse(200, {'orderedItems': []}),
+    }
+
+    def fake_request(method, url, **kwargs):
+        return responses[url]
+
+    monkeypatch.setattr(fediverse.requests, 'request', fake_request)
+    monkeypatch.setattr(fediverse, '_assert_public_host', lambda host: None)
+
+    result = activitypub.read_outbox(OUTBOX)
+    assert result == {'orderedItems': []}
+
+
+def test_read_outbox_requires_outbox_url():
+    with pytest.raises(fediverse.FediverseError):
+        activitypub.read_outbox(None)
+
+
+def test_read_outbox_raises_on_error_status(monkeypatch):
+    _stub_request(monkeypatch, _FakeJSONResponse(404, {}))
+    with pytest.raises(fediverse.FediverseError):
+        activitypub.read_outbox(OUTBOX)
+
+
+def test_read_outbox_raises_on_network_error(monkeypatch):
+    def fail(*a, **k):
+        raise fediverse.requests.RequestException('boom')
+    monkeypatch.setattr(fediverse.requests, 'request', fail)
+    monkeypatch.setattr(fediverse, '_assert_public_host', lambda host: None)
+    with pytest.raises(fediverse.FediverseError):
+        activitypub.read_outbox(OUTBOX)

--- a/tests/test_api_achievements.py
+++ b/tests/test_api_achievements.py
@@ -1,0 +1,136 @@
+# Nota: igual que en test_api_games.py, cada request de `testapp` corre en su
+# propia transaccion que se aborta al final (ver conftest.py), asi que las
+# pruebas que necesitan que un logro otorgado en un request exista en el
+# siguiente usan el fixture `game_data_bridge` (mismo patron que fediverse_stub
+# usa para usuarios). Lo que no lo necesita solo prueba lo que un unico
+# request/response puede demostrar.
+
+
+def test_badges_requires_auth(testapp):
+    testapp.post_json('/api/v1/sipping/node-x/badges', {'id': 'a', 'title': 'A'}, status=401)
+
+
+def test_award_badge_creates_it(testapp, login_as_fediverse_user):
+    login_as_fediverse_user()
+    body = testapp.post_json('/api/v1/sipping/node-a/badges', {
+        'id': 'high-score-100', 'title': 'Cien puntos', 'icon': '🏆',
+    }, status=200).json
+    assert body['badges'] == [{
+        'id': 'high-score-100', 'title': 'Cien puntos', 'icon': '🏆',
+        'awarded_at': body['badges'][0]['awarded_at'],
+    }]
+
+
+def test_award_badge_rejects_missing_id(testapp, login_as_fediverse_user):
+    login_as_fediverse_user()
+    testapp.post_json('/api/v1/sipping/node-a/badges', {'title': 'Sin id'}, status=400)
+
+
+def test_award_badge_rejects_missing_title(testapp, login_as_fediverse_user):
+    login_as_fediverse_user()
+    testapp.post_json('/api/v1/sipping/node-a/badges', {'id': 'x'}, status=400)
+
+
+def test_award_badge_rejects_non_string_icon(testapp, login_as_fediverse_user):
+    login_as_fediverse_user()
+    testapp.post_json('/api/v1/sipping/node-a/badges', {'id': 'x', 'title': 'X', 'icon': 123}, status=400)
+
+
+def test_achievements_requires_auth(testapp):
+    testapp.get('/api/v1/achievements', status=401)
+
+
+def test_achievements_empty_when_no_badges(testapp, login_as_fediverse_user):
+    login_as_fediverse_user()
+    body = testapp.get('/api/v1/achievements', status=200).json
+    assert body['achievements'] == []
+
+
+def test_share_requires_auth(testapp):
+    testapp.post_json('/api/v1/share', {'nodeid': 'a', 'badge_id': 'b'}, status=401)
+
+
+def test_share_rejects_missing_fields(testapp, login_as_fediverse_user):
+    login_as_fediverse_user()
+    testapp.post_json('/api/v1/share', {}, status=400)
+
+
+def test_share_404_when_badge_was_never_awarded(testapp, login_as_fediverse_user):
+    login_as_fediverse_user()
+    testapp.post_json('/api/v1/share', {'nodeid': 'node-a', 'badge_id': 'never-awarded'}, status=404)
+
+
+def test_share_publishes_awarded_badge_to_the_fediverse(testapp, login_as_fediverse_user, game_data_bridge, monkeypatch):
+    from honeycomb.security import activitypub
+
+    calls = []
+
+    def fake_publish_note(outbox_url, access_token, content, to_public=True):
+        calls.append((outbox_url, access_token, content))
+        return {'id': 'https://fake.fediverse.test/activities/1'}
+
+    monkeypatch.setattr(activitypub, 'publish_note', fake_publish_note)
+
+    login_as_fediverse_user()
+    testapp.post_json('/api/v1/sipping/node-a/badges', {'id': 'high-score-100', 'title': 'Cien puntos'}, status=200)
+
+    body = testapp.post_json('/api/v1/share', {'nodeid': 'node-a', 'badge_id': 'high-score-100'}, status=200).json
+    assert body['status'] == 'ok'
+    assert body['activity'] == {'id': 'https://fake.fediverse.test/activities/1'}
+
+    assert len(calls) == 1
+    outbox_url, access_token, content = calls[0]
+    assert outbox_url == 'https://fake.fediverse.test/users/tester/outbox'
+    assert access_token == 'fake-access-token'
+    assert 'Cien puntos' in content
+
+
+def test_share_uses_custom_message_when_given(testapp, login_as_fediverse_user, game_data_bridge, monkeypatch):
+    from honeycomb.security import activitypub
+
+    calls = []
+    monkeypatch.setattr(
+        activitypub, 'publish_note',
+        lambda outbox_url, access_token, content, to_public=True: calls.append(content) or {'id': 'x'},
+    )
+
+    login_as_fediverse_user()
+    testapp.post_json('/api/v1/sipping/node-a/badges', {'id': 'badge-x', 'title': 'X'}, status=200)
+    testapp.post_json('/api/v1/share', {
+        'nodeid': 'node-a', 'badge_id': 'badge-x', 'message': 'Mensaje personalizado!',
+    }, status=200)
+
+    assert calls == ['Mensaje personalizado!']
+
+
+def test_share_returns_400_without_encryption_key_configured(testapp, login_as_fediverse_user, game_data_bridge, monkeypatch):
+    monkeypatch.setitem(testapp.app.registry.settings, 'honeycomb.token_encryption_key', '')
+
+    login_as_fediverse_user()
+    testapp.post_json('/api/v1/sipping/node-a/badges', {'id': 'badge-x', 'title': 'X'}, status=200)
+    testapp.post_json('/api/v1/share', {'nodeid': 'node-a', 'badge_id': 'badge-x'}, status=400)
+
+
+def test_share_returns_502_when_the_instance_rejects_the_post(testapp, login_as_fediverse_user, game_data_bridge, monkeypatch):
+    from honeycomb.security import activitypub, fediverse
+
+    def failing_publish(outbox_url, access_token, content, to_public=True):
+        raise fediverse.FediverseError('la instancia rechazo la publicacion')
+
+    monkeypatch.setattr(activitypub, 'publish_note', failing_publish)
+
+    login_as_fediverse_user()
+    testapp.post_json('/api/v1/sipping/node-a/badges', {'id': 'badge-x', 'title': 'X'}, status=200)
+    testapp.post_json('/api/v1/share', {'nodeid': 'node-a', 'badge_id': 'badge-x'}, status=502)
+
+
+def test_share_returns_a_distinct_error_for_accounts_without_a_fediverse_identity(
+    testapp, register_as_local_user, game_data_bridge,
+):
+    """Una cuenta local pura (sin Fediverso vinculado) debe recibir un error que
+    invite a vincular, distinto del que invita a volver a iniciar sesion."""
+    register_as_local_user('alice', 'correct horse battery staple')
+    testapp.post_json('/api/v1/sipping/node-a/badges', {'id': 'badge-x', 'title': 'X'}, status=200)
+
+    body = testapp.post_json('/api/v1/share', {'nodeid': 'node-a', 'badge_id': 'badge-x'}, status=400).json
+    assert 'vincula' in body['error']

--- a/tests/test_api_games.py
+++ b/tests/test_api_games.py
@@ -5,59 +5,55 @@
 # what a single request/response can prove.
 
 
-def _login(testapp):
-    testapp.get('/login', status=303)
-
-
 def test_me_requires_auth(testapp):
     testapp.get('/api/v1/me', status=401)
 
 
-def test_me_returns_authenticated_user(testapp):
-    _login(testapp)
+def test_me_returns_authenticated_user(testapp, login_as_fediverse_user):
+    fediverse_account = login_as_fediverse_user()
     body = testapp.get('/api/v1/me', status=200).json
-    assert body['userid'] == 'convida@unam.social'
+    assert body['userid'] == fediverse_account['userid']
     assert set(body.keys()) == {'userid', 'displayname', 'username', 'icon', 'background'}
 
 
 def test_game_data_requires_auth(testapp):
-    testapp.get('/api/v1/games/node-x/data', status=401)
-    testapp.post_json('/api/v1/games/node-x/data', {'stats': {}}, status=401)
+    testapp.get('/api/v1/sipping/node-x', status=401)
+    testapp.post_json('/api/v1/sipping/node-x', {'stats': {}}, status=401)
 
 
-def test_game_data_get_defaults_when_untouched(testapp):
-    _login(testapp)
-    body = testapp.get('/api/v1/games/node-untouched/data', status=200).json
+def test_game_data_get_defaults_when_untouched(testapp, login_as_fediverse_user):
+    login_as_fediverse_user()
+    body = testapp.get('/api/v1/sipping/node-untouched', status=200).json
     assert body['interactions'] == 0
     assert body['stats'] == {}
     assert body['preferences'] == {}
 
 
-def test_game_data_post_creates_record_and_counts_first_interaction(testapp):
-    _login(testapp)
-    body = testapp.post_json('/api/v1/games/node-a/data', {'stats': {'highscore': 10}}, status=200).json
+def test_game_data_post_creates_record_and_counts_first_interaction(testapp, login_as_fediverse_user):
+    login_as_fediverse_user()
+    body = testapp.post_json('/api/v1/sipping/node-a', {'stats': {'highscore': 10}}, status=200).json
     assert body['interactions'] == 1
     assert body['stats'] == {'highscore': 10}
 
 
-def test_game_data_post_ignores_client_supplied_interactions(testapp):
-    _login(testapp)
-    body = testapp.post_json('/api/v1/games/node-c/data', {'interactions': 999, 'stats': {}}, status=200).json
+def test_game_data_post_ignores_client_supplied_interactions(testapp, login_as_fediverse_user):
+    login_as_fediverse_user()
+    body = testapp.post_json('/api/v1/sipping/node-c', {'interactions': 999, 'stats': {}}, status=200).json
     assert body['interactions'] == 1
 
 
-def test_game_data_post_accepts_replace_flag(testapp):
-    _login(testapp)
-    body = testapp.post_json('/api/v1/games/node-d/data', {'stats': {'highscore': 20}, 'replace': True}, status=200).json
+def test_game_data_post_accepts_replace_flag(testapp, login_as_fediverse_user):
+    login_as_fediverse_user()
+    body = testapp.post_json('/api/v1/sipping/node-d', {'stats': {'highscore': 20}, 'replace': True}, status=200).json
     assert body['stats'] == {'highscore': 20}
 
 
-def test_game_data_post_saves_preferences(testapp):
-    _login(testapp)
-    body = testapp.post_json('/api/v1/games/node-e/data', {'preferences': {'difficulty': 'hard'}}, status=200).json
+def test_game_data_post_saves_preferences(testapp, login_as_fediverse_user):
+    login_as_fediverse_user()
+    body = testapp.post_json('/api/v1/sipping/node-e', {'preferences': {'difficulty': 'hard'}}, status=200).json
     assert body['preferences'] == {'difficulty': 'hard'}
 
 
-def test_game_data_post_rejects_non_object_stats(testapp):
-    _login(testapp)
-    testapp.post_json('/api/v1/games/node-f/data', {'stats': 'not-an-object'}, status=400)
+def test_game_data_post_rejects_non_object_stats(testapp, login_as_fediverse_user):
+    login_as_fediverse_user()
+    testapp.post_json('/api/v1/sipping/node-f', {'stats': 'not-an-object'}, status=400)

--- a/tests/test_api_games.py
+++ b/tests/test_api_games.py
@@ -1,0 +1,63 @@
+# Note: the testapp fixture aborts ZODB writes at the end of every single
+# request (see conftest.py), so state never carries over between requests
+# even within one test. Cross-request persistence (merge, counters) is
+# covered at the model level in test_models.py; tests here only assert on
+# what a single request/response can prove.
+
+
+def _login(testapp):
+    testapp.get('/login', status=303)
+
+
+def test_me_requires_auth(testapp):
+    testapp.get('/api/v1/me', status=401)
+
+
+def test_me_returns_authenticated_user(testapp):
+    _login(testapp)
+    body = testapp.get('/api/v1/me', status=200).json
+    assert body['userid'] == 'convida@unam.social'
+    assert set(body.keys()) == {'userid', 'displayname', 'username', 'icon', 'background'}
+
+
+def test_game_data_requires_auth(testapp):
+    testapp.get('/api/v1/games/node-x/data', status=401)
+    testapp.post_json('/api/v1/games/node-x/data', {'stats': {}}, status=401)
+
+
+def test_game_data_get_defaults_when_untouched(testapp):
+    _login(testapp)
+    body = testapp.get('/api/v1/games/node-untouched/data', status=200).json
+    assert body['interactions'] == 0
+    assert body['stats'] == {}
+    assert body['preferences'] == {}
+
+
+def test_game_data_post_creates_record_and_counts_first_interaction(testapp):
+    _login(testapp)
+    body = testapp.post_json('/api/v1/games/node-a/data', {'stats': {'highscore': 10}}, status=200).json
+    assert body['interactions'] == 1
+    assert body['stats'] == {'highscore': 10}
+
+
+def test_game_data_post_ignores_client_supplied_interactions(testapp):
+    _login(testapp)
+    body = testapp.post_json('/api/v1/games/node-c/data', {'interactions': 999, 'stats': {}}, status=200).json
+    assert body['interactions'] == 1
+
+
+def test_game_data_post_accepts_replace_flag(testapp):
+    _login(testapp)
+    body = testapp.post_json('/api/v1/games/node-d/data', {'stats': {'highscore': 20}, 'replace': True}, status=200).json
+    assert body['stats'] == {'highscore': 20}
+
+
+def test_game_data_post_saves_preferences(testapp):
+    _login(testapp)
+    body = testapp.post_json('/api/v1/games/node-e/data', {'preferences': {'difficulty': 'hard'}}, status=200).json
+    assert body['preferences'] == {'difficulty': 'hard'}
+
+
+def test_game_data_post_rejects_non_object_stats(testapp):
+    _login(testapp)
+    testapp.post_json('/api/v1/games/node-f/data', {'stats': 'not-an-object'}, status=400)

--- a/tests/test_api_games.py
+++ b/tests/test_api_games.py
@@ -13,7 +13,29 @@ def test_me_returns_authenticated_user(testapp, login_as_fediverse_user):
     fediverse_account = login_as_fediverse_user()
     body = testapp.get('/api/v1/me', status=200).json
     assert body['userid'] == fediverse_account['userid']
-    assert set(body.keys()) == {'userid', 'displayname', 'username', 'icon', 'background'}
+    assert set(body.keys()) == {
+        'userid', 'displayname', 'username', 'icon', 'background', 'identities', 'can_share',
+    }
+
+
+def test_me_lists_the_fediverse_identity_after_login(testapp, login_as_fediverse_user, fediverse_stub):
+    login_as_fediverse_user()
+    body = testapp.get('/api/v1/me', status=200).json
+    assert body['identities'] == [{'kind': 'fediverse', 'value': fediverse_stub['userid']}]
+
+
+def test_me_can_share_is_false_without_a_stored_token(testapp, login_as_fediverse_user, monkeypatch):
+    monkeypatch.setitem(testapp.app.registry.settings, 'honeycomb.token_encryption_key', '')
+    login_as_fediverse_user()
+    body = testapp.get('/api/v1/me', status=200).json
+    assert body['can_share'] is False
+
+
+def test_me_can_share_is_true_with_a_stored_token(testapp, login_as_fediverse_user):
+    """testing.ini trae una clave real, asi que el flujo completo si guarda un token."""
+    login_as_fediverse_user()
+    body = testapp.get('/api/v1/me', status=200).json
+    assert body['can_share'] is True
 
 
 def test_game_data_requires_auth(testapp):
@@ -57,3 +79,26 @@ def test_game_data_post_saves_preferences(testapp, login_as_fediverse_user):
 def test_game_data_post_rejects_non_object_stats(testapp, login_as_fediverse_user):
     login_as_fediverse_user()
     testapp.post_json('/api/v1/sipping/node-f', {'stats': 'not-an-object'}, status=400)
+
+
+def test_game_data_post_has_no_key_limit_by_default(testapp, login_as_fediverse_user):
+    """honeycomb.max_game_payload_keys vacio/ausente (default de fabrica) = sin limite."""
+    login_as_fediverse_user()
+    big_stats = {f'k{i}': i for i in range(200)}
+    body = testapp.post_json('/api/v1/sipping/node-g', {'stats': big_stats}, status=200).json
+    assert len(body['stats']) == 200
+
+
+def test_game_data_post_enforces_configured_key_limit(testapp, login_as_fediverse_user, monkeypatch):
+    monkeypatch.setitem(testapp.app.registry.settings, 'honeycomb.max_game_payload_keys', '5')
+    login_as_fediverse_user()
+    too_many = {f'k{i}': i for i in range(6)}
+    testapp.post_json('/api/v1/sipping/node-h', {'stats': too_many}, status=400)
+
+
+def test_game_data_post_configured_limit_allows_payload_within_it(testapp, login_as_fediverse_user, monkeypatch):
+    monkeypatch.setitem(testapp.app.registry.settings, 'honeycomb.max_game_payload_keys', '5')
+    login_as_fediverse_user()
+    ok_stats = {f'k{i}': i for i in range(5)}
+    body = testapp.post_json('/api/v1/sipping/node-i', {'stats': ok_stats}, status=200).json
+    assert len(body['stats']) == 5

--- a/tests/test_auth_fediverse.py
+++ b/tests/test_auth_fediverse.py
@@ -8,26 +8,30 @@ def _redirects_to_login_error(location):
 
 def test_login_page_renders_form(testapp):
     page = testapp.get('/login', status=200)
-    assert 'csrf_token' in page.form.fields
-    assert 'handle' in page.form.fields
+    fediverse_form = page.forms['fediverse-login-form']
+    assert 'csrf_token' in fediverse_form.fields
+    assert 'handle' in fediverse_form.fields
+    local_form = page.forms['local-login-form']
+    assert 'username' in local_form.fields
+    assert 'password' in local_form.fields
 
 
 def test_login_page_csrf_token_stable_across_reloads(testapp):
-    first = testapp.get('/login', status=200).form['csrf_token'].value
-    second = testapp.get('/login', status=200).form['csrf_token'].value
+    first = testapp.get('/login', status=200).forms['fediverse-login-form']['csrf_token'].value
+    second = testapp.get('/login', status=200).forms['fediverse-login-form']['csrf_token'].value
     assert first == second
 
 
 def test_login_start_rejects_malformed_handle(testapp):
     login_page = testapp.get('/login', status=200)
-    csrf_token = login_page.form['csrf_token'].value
+    csrf_token = login_page.forms['fediverse-login-form']['csrf_token'].value
     resp = testapp.post('/api/v1/auth/login', {'handle': 'not-a-handle', 'csrf_token': csrf_token}, status=303)
     assert _redirects_to_login_error(resp.headers['Location'])
 
 
 def test_login_start_redirects_to_authorize_url(testapp, fediverse_stub):
     login_page = testapp.get('/login', status=200)
-    csrf_token = login_page.form['csrf_token'].value
+    csrf_token = login_page.forms['fediverse-login-form']['csrf_token'].value
     resp = testapp.post('/api/v1/auth/login', {
         'handle': fediverse_stub['handle'],
         'csrf_token': csrf_token,
@@ -41,11 +45,40 @@ def test_login_start_redirects_to_authorize_url(testapp, fediverse_stub):
     assert 'code_challenge' in params  # el stub declara soporte S256
 
 
+def test_login_start_uses_actor_declared_oauth_endpoints(testapp, fediverse_stub, monkeypatch):
+    """Cuando el Actor si declara endpoints.oauth* (caso unam.social/Pleroma), se usan
+    esos en vez de las rutas hardcodeadas de la API de Mastodon."""
+    from honeycomb.security import fediverse
+
+    actor_with_endpoints = {
+        'id': f"https://{fediverse_stub['domain']}/users/tester",
+        'preferredUsername': 'tester',
+        'name': 'Test User',
+        'inbox': f"https://{fediverse_stub['domain']}/users/tester/inbox",
+        'outbox': f"https://{fediverse_stub['domain']}/users/tester/outbox",
+        'endpoints': {
+            'oauthRegistrationEndpoint': f"https://{fediverse_stub['domain']}/custom/apps",
+            'oauthAuthorizationEndpoint': f"https://{fediverse_stub['domain']}/custom/authorize",
+            'oauthTokenEndpoint': f"https://{fediverse_stub['domain']}/custom/token",
+        },
+    }
+    monkeypatch.setattr(fediverse, 'fetch_actor', lambda actor_url: dict(actor_with_endpoints))
+
+    login_page = testapp.get('/login', status=200)
+    csrf_token = login_page.forms['fediverse-login-form']['csrf_token'].value
+    resp = testapp.post('/api/v1/auth/login', {
+        'handle': fediverse_stub['handle'],
+        'csrf_token': csrf_token,
+    }, status=303)
+    location = resp.headers['Location']
+    assert location.startswith(f"https://{fediverse_stub['domain']}/custom/authorize?")
+
+
 def test_login_start_rejects_denylisted_domain(testapp, fediverse_stub, monkeypatch):
     monkeypatch.setitem(testapp.app.registry.settings, 'fediverse.denylist', fediverse_stub['domain'])
 
     login_page = testapp.get('/login', status=200)
-    csrf_token = login_page.form['csrf_token'].value
+    csrf_token = login_page.forms['fediverse-login-form']['csrf_token'].value
     resp = testapp.post('/api/v1/auth/login', {
         'handle': fediverse_stub['handle'],
         'csrf_token': csrf_token,
@@ -55,10 +88,13 @@ def test_login_start_rejects_denylisted_domain(testapp, fediverse_stub, monkeypa
 
 def test_login_start_rejects_domain_without_nodeinfo(testapp, fediverse_stub, monkeypatch):
     from honeycomb.security import fediverse
+    # Simula que TAMPOCO se pudo resolver el Actor via WebFinger: sin eso, el actor ya
+    # no sirve como confirmacion de que hay un servidor real, y se cae al chequeo de nodeinfo.
+    monkeypatch.setattr(fediverse, 'discover_actor_url', lambda username, domain: None)
     monkeypatch.setattr(fediverse, 'discover_nodeinfo', lambda domain: None)
 
     login_page = testapp.get('/login', status=200)
-    csrf_token = login_page.form['csrf_token'].value
+    csrf_token = login_page.forms['fediverse-login-form']['csrf_token'].value
     resp = testapp.post('/api/v1/auth/login', {
         'handle': f"user@{fediverse_stub['domain']}",
         'csrf_token': csrf_token,
@@ -73,7 +109,7 @@ def test_callback_rejects_missing_state(testapp):
 
 def test_callback_rejects_mismatched_state(testapp, fediverse_stub):
     login_page = testapp.get('/login', status=200)
-    csrf_token = login_page.form['csrf_token'].value
+    csrf_token = login_page.forms['fediverse-login-form']['csrf_token'].value
     testapp.post('/api/v1/auth/login', {
         'handle': fediverse_stub['handle'],
         'csrf_token': csrf_token,
@@ -85,7 +121,7 @@ def test_callback_rejects_mismatched_state(testapp, fediverse_stub):
 
 def test_callback_rejects_missing_code(testapp, fediverse_stub):
     login_page = testapp.get('/login', status=200)
-    csrf_token = login_page.form['csrf_token'].value
+    csrf_token = login_page.forms['fediverse-login-form']['csrf_token'].value
     start_resp = testapp.post('/api/v1/auth/login', {
         'handle': fediverse_stub['handle'],
         'csrf_token': csrf_token,
@@ -103,6 +139,27 @@ def test_full_login_flow_sets_identity(testapp, login_as_fediverse_user, fediver
     assert body['username'] == fediverse_stub['handle']
 
 
+def test_full_login_flow_encrypts_and_stores_access_token(testapp, login_as_fediverse_user, fediverse_stub):
+    """testing.ini trae una clave real, asi que el flujo completo debe cifrar y
+    guardar el token (fake-access-token, del stub de exchange_code)."""
+    from honeycomb.security import tokenstore
+
+    login_as_fediverse_user()
+    stored_user = fediverse_stub['get_stored_user']()
+    assert stored_user.access_token_encrypted is not None
+    assert stored_user.access_token_encrypted != 'fake-access-token'
+
+    settings = testapp.app.registry.settings
+    assert tokenstore.decrypt_token(settings, stored_user.access_token_encrypted) == 'fake-access-token'
+
+
+def test_me_endpoint_never_exposes_the_access_token(testapp, login_as_fediverse_user):
+    login_as_fediverse_user()
+    body = testapp.get('/api/v1/me', status=200).json
+    assert 'access_token' not in body
+    assert 'access_token_encrypted' not in body
+
+
 def test_second_login_to_same_domain_reuses_cached_app(testapp, fediverse_stub, monkeypatch):
     from honeycomb.security import fediverse
 
@@ -117,10 +174,45 @@ def test_second_login_to_same_domain_reuses_cached_app(testapp, fediverse_stub, 
 
     for _ in range(2):
         login_page = testapp.get('/login', status=200)
-        csrf_token = login_page.form['csrf_token'].value
+        csrf_token = login_page.forms['fediverse-login-form']['csrf_token'].value
         testapp.post('/api/v1/auth/login', {
             'handle': fediverse_stub['handle'],
             'csrf_token': csrf_token,
         }, status=303)
 
     assert len(calls) == 1
+
+
+def test_relogin_via_fediverse_does_not_wipe_a_linked_password_hash(testapp, login_as_fediverse_user, fediverse_stub):
+    """Regresion: el callback reemplazaba el DroneUser entero en cada login, lo que
+    habria borrado un password_hash vinculado. Ahora usa update_profile.
+
+    testapp.reset() simula volver en una sesion nueva (cerrar el navegador y
+    entrar otro dia) -- si no se limpian las cookies, la segunda llamada a
+    login_as_fediverse_user ya estaria autenticada y /login la redirigiria de
+    entrada (ese es justamente el caso de vincular, no de volver a entrar)."""
+    login_as_fediverse_user()
+    stored_user = fediverse_stub['get_stored_user']()
+    stored_user.password_hash = 'scrypt$n=16384,r=8,p=1$fake-salt$fake-digest'
+
+    testapp.reset()
+    login_as_fediverse_user()
+
+    stored_user_again = fediverse_stub['get_stored_user']()
+    assert stored_user_again.password_hash == 'scrypt$n=16384,r=8,p=1$fake-salt$fake-digest'
+
+
+def test_relogin_via_fediverse_still_refreshes_the_access_token(testapp, login_as_fediverse_user, fediverse_stub):
+    """El arreglo de la trampa 1 no debe dejar de refrescar el token en cada login."""
+    from honeycomb.security import tokenstore
+
+    login_as_fediverse_user()
+    first_token = fediverse_stub['get_stored_user']().access_token_encrypted
+
+    testapp.reset()
+    login_as_fediverse_user()
+    second_token = fediverse_stub['get_stored_user']().access_token_encrypted
+
+    settings = testapp.app.registry.settings
+    assert tokenstore.decrypt_token(settings, second_token) == 'fake-access-token'
+    assert first_token is not None and second_token is not None

--- a/tests/test_auth_fediverse.py
+++ b/tests/test_auth_fediverse.py
@@ -1,0 +1,126 @@
+import urllib.parse
+
+
+def _redirects_to_login_error(location):
+    parts = urllib.parse.urlsplit(location)
+    return parts.path == '/login' and 'error' in urllib.parse.parse_qs(parts.query)
+
+
+def test_login_page_renders_form(testapp):
+    page = testapp.get('/login', status=200)
+    assert 'csrf_token' in page.form.fields
+    assert 'handle' in page.form.fields
+
+
+def test_login_page_csrf_token_stable_across_reloads(testapp):
+    first = testapp.get('/login', status=200).form['csrf_token'].value
+    second = testapp.get('/login', status=200).form['csrf_token'].value
+    assert first == second
+
+
+def test_login_start_rejects_malformed_handle(testapp):
+    login_page = testapp.get('/login', status=200)
+    csrf_token = login_page.form['csrf_token'].value
+    resp = testapp.post('/api/v1/auth/login', {'handle': 'not-a-handle', 'csrf_token': csrf_token}, status=303)
+    assert _redirects_to_login_error(resp.headers['Location'])
+
+
+def test_login_start_redirects_to_authorize_url(testapp, fediverse_stub):
+    login_page = testapp.get('/login', status=200)
+    csrf_token = login_page.form['csrf_token'].value
+    resp = testapp.post('/api/v1/auth/login', {
+        'handle': fediverse_stub['handle'],
+        'csrf_token': csrf_token,
+    }, status=303)
+    location = resp.headers['Location']
+    assert location.startswith(f"https://{fediverse_stub['domain']}/oauth/authorize?")
+    params = urllib.parse.parse_qs(urllib.parse.urlsplit(location).query)
+    assert params['client_id'] == ['fake-client-id']
+    assert params['response_type'] == ['code']
+    assert 'state' in params
+    assert 'code_challenge' in params  # el stub declara soporte S256
+
+
+def test_login_start_rejects_denylisted_domain(testapp, fediverse_stub, monkeypatch):
+    monkeypatch.setitem(testapp.app.registry.settings, 'fediverse.denylist', fediverse_stub['domain'])
+
+    login_page = testapp.get('/login', status=200)
+    csrf_token = login_page.form['csrf_token'].value
+    resp = testapp.post('/api/v1/auth/login', {
+        'handle': fediverse_stub['handle'],
+        'csrf_token': csrf_token,
+    }, status=303)
+    assert 'no esta permitido' in urllib.parse.unquote(resp.headers['Location'])
+
+
+def test_login_start_rejects_domain_without_nodeinfo(testapp, fediverse_stub, monkeypatch):
+    from honeycomb.security import fediverse
+    monkeypatch.setattr(fediverse, 'discover_nodeinfo', lambda domain: None)
+
+    login_page = testapp.get('/login', status=200)
+    csrf_token = login_page.form['csrf_token'].value
+    resp = testapp.post('/api/v1/auth/login', {
+        'handle': f"user@{fediverse_stub['domain']}",
+        'csrf_token': csrf_token,
+    }, status=303)
+    assert 'No encontramos un servidor' in urllib.parse.unquote(resp.headers['Location'])
+
+
+def test_callback_rejects_missing_state(testapp):
+    resp = testapp.get('/api/v1/auth/callback', {'code': 'whatever'}, status=303)
+    assert _redirects_to_login_error(resp.headers['Location'])
+
+
+def test_callback_rejects_mismatched_state(testapp, fediverse_stub):
+    login_page = testapp.get('/login', status=200)
+    csrf_token = login_page.form['csrf_token'].value
+    testapp.post('/api/v1/auth/login', {
+        'handle': fediverse_stub['handle'],
+        'csrf_token': csrf_token,
+    }, status=303)
+
+    resp = testapp.get('/api/v1/auth/callback', {'code': 'fake-code', 'state': 'wrong-state'}, status=303)
+    assert _redirects_to_login_error(resp.headers['Location'])
+
+
+def test_callback_rejects_missing_code(testapp, fediverse_stub):
+    login_page = testapp.get('/login', status=200)
+    csrf_token = login_page.form['csrf_token'].value
+    start_resp = testapp.post('/api/v1/auth/login', {
+        'handle': fediverse_stub['handle'],
+        'csrf_token': csrf_token,
+    }, status=303)
+    state = urllib.parse.parse_qs(urllib.parse.urlsplit(start_resp.headers['Location']).query)['state'][0]
+
+    resp = testapp.get('/api/v1/auth/callback', {'state': state}, status=303)
+    assert _redirects_to_login_error(resp.headers['Location'])
+
+
+def test_full_login_flow_sets_identity(testapp, login_as_fediverse_user, fediverse_stub):
+    login_as_fediverse_user()
+    body = testapp.get('/api/v1/me', status=200).json
+    assert body['userid'] == fediverse_stub['userid']
+    assert body['username'] == fediverse_stub['handle']
+
+
+def test_second_login_to_same_domain_reuses_cached_app(testapp, fediverse_stub, monkeypatch):
+    from honeycomb.security import fediverse
+
+    calls = []
+    original_register_app = fediverse.register_app
+
+    def counting_register_app(*args, **kwargs):
+        calls.append(1)
+        return original_register_app(*args, **kwargs)
+
+    monkeypatch.setattr(fediverse, 'register_app', counting_register_app)
+
+    for _ in range(2):
+        login_page = testapp.get('/login', status=200)
+        csrf_token = login_page.form['csrf_token'].value
+        testapp.post('/api/v1/auth/login', {
+            'handle': fediverse_stub['handle'],
+            'csrf_token': csrf_token,
+        }, status=303)
+
+    assert len(calls) == 1

--- a/tests/test_fediverse.py
+++ b/tests/test_fediverse.py
@@ -1,0 +1,200 @@
+import socket
+
+import pytest
+
+from honeycomb.security import fediverse
+
+
+def _fake_getaddrinfo(ip):
+    def _impl(host, port, *args, **kwargs):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, '', (ip, 0))]
+    return _impl
+
+
+def test_is_public_ip_accepts_public():
+    assert fediverse._is_public_ip('8.8.8.8') is True
+
+
+def test_is_public_ip_rejects_private_ranges():
+    assert fediverse._is_public_ip('10.0.0.1') is False
+    assert fediverse._is_public_ip('127.0.0.1') is False
+    assert fediverse._is_public_ip('169.254.169.254') is False
+    assert fediverse._is_public_ip('0.0.0.0') is False
+
+
+def test_assert_public_host_allows_public_ip(monkeypatch):
+    monkeypatch.setattr(socket, 'getaddrinfo', _fake_getaddrinfo('93.184.216.34'))
+    fediverse._assert_public_host('example.com')
+
+
+def test_assert_public_host_rejects_private_ip(monkeypatch):
+    monkeypatch.setattr(socket, 'getaddrinfo', _fake_getaddrinfo('127.0.0.1'))
+    with pytest.raises(fediverse.FediverseError):
+        fediverse._assert_public_host('evil.example')
+
+
+def test_assert_public_host_rejects_link_local_metadata_ip(monkeypatch):
+    monkeypatch.setattr(socket, 'getaddrinfo', _fake_getaddrinfo('169.254.169.254'))
+    with pytest.raises(fediverse.FediverseError):
+        fediverse._assert_public_host('evil.example')
+
+
+def test_assert_public_host_rejects_dns_failure(monkeypatch):
+    def _raise(*args, **kwargs):
+        raise socket.gaierror('nope')
+    monkeypatch.setattr(socket, 'getaddrinfo', _raise)
+    with pytest.raises(fediverse.FediverseError):
+        fediverse._assert_public_host('doesnotexist.invalid')
+
+
+def test_parse_handle_accepts_at_prefix():
+    assert fediverse.parse_handle('@user@example.social') == ('user', 'example.social')
+
+
+def test_parse_handle_accepts_without_at_prefix():
+    assert fediverse.parse_handle('user@example.social') == ('user', 'example.social')
+
+
+def test_parse_handle_lowercases_domain():
+    _username, domain = fediverse.parse_handle('User@Example.Social')
+    assert domain == 'example.social'
+
+
+def test_parse_handle_rejects_missing_at():
+    with pytest.raises(fediverse.FediverseError):
+        fediverse.parse_handle('notahandle')
+
+
+def test_parse_handle_rejects_empty():
+    with pytest.raises(fediverse.FediverseError):
+        fediverse.parse_handle('')
+
+
+def test_parse_handle_rejects_domain_without_dot():
+    with pytest.raises(fediverse.FediverseError):
+        fediverse.parse_handle('user@localhost')
+
+
+def test_generate_pkce_pair_shapes():
+    verifier, challenge = fediverse.generate_pkce_pair()
+    assert 43 <= len(verifier) <= 128
+    assert len(challenge) > 0
+    assert verifier != challenge
+
+
+def test_states_match_true_for_equal():
+    assert fediverse.states_match('abc', 'abc') is True
+
+
+def test_states_match_false_for_different():
+    assert fediverse.states_match('abc', 'xyz') is False
+
+
+def test_states_match_false_for_missing():
+    assert fediverse.states_match(None, 'abc') is False
+    assert fediverse.states_match('abc', None) is False
+
+
+def test_choose_scope_prefers_profile_when_supported():
+    assert fediverse.choose_scope({'scopes_supported': ['read', 'profile']}) == 'profile'
+
+
+def test_choose_scope_falls_back_without_profile():
+    assert fediverse.choose_scope({'scopes_supported': ['read']}) == 'read:accounts'
+
+
+def test_choose_scope_falls_back_without_metadata():
+    assert fediverse.choose_scope(None) == 'read:accounts'
+
+
+def test_supports_pkce_true_when_s256_listed():
+    assert fediverse.supports_pkce({'code_challenge_methods_supported': ['S256']}) is True
+
+
+def test_supports_pkce_false_without_metadata():
+    assert fediverse.supports_pkce(None) is False
+
+
+def test_canonical_userid_prefers_actor_uri():
+    account = {'uri': 'https://example.social/users/alice', 'id': '42'}
+    assert fediverse.canonical_userid('example.social', account) == 'https://example.social/users/alice'
+
+
+def test_canonical_userid_falls_back_to_host_and_id():
+    account = {'id': '42'}
+    assert fediverse.canonical_userid('example.social', account) == 'example.social#42'
+
+
+def test_account_to_drone_user_maps_fields():
+    account = {
+        'uri': 'https://example.social/users/alice',
+        'id': '42',
+        'username': 'alice',
+        'acct': 'alice',
+        'display_name': 'Alice',
+        'avatar': 'https://example.social/avatar.png',
+        'header': 'https://example.social/header.png',
+    }
+    user = fediverse.account_to_drone_user('example.social', account)
+    assert user.userid == 'https://example.social/users/alice'
+    assert user.display_name == 'Alice'
+    assert user.username == 'alice@example.social'
+    assert user.icon == 'https://example.social/avatar.png'
+    assert user.background == 'https://example.social/header.png'
+
+
+def test_account_to_drone_user_handles_nested_image_objects():
+    account = {
+        'id': '7',
+        'username': 'bob',
+        'avatar': {'url': 'https://example.social/bob-avatar.png'},
+        'header': None,
+    }
+    user = fediverse.account_to_drone_user('example.social', account)
+    assert user.icon == 'https://example.social/bob-avatar.png'
+    assert user.background is None
+
+
+class _FakeAppResponse:
+    status_code = 200
+    is_redirect = False
+    is_permanent_redirect = False
+
+    def json(self):
+        return {'client_id': 'id', 'client_secret': 'secret'}
+
+
+def _stub_network(monkeypatch):
+    monkeypatch.setattr(fediverse.requests, 'request', lambda *a, **k: _FakeAppResponse())
+    monkeypatch.setattr(fediverse, '_assert_public_host', lambda host: None)
+
+
+def test_register_app_enforces_per_domain_rate_limit(monkeypatch):
+    limiter = fediverse._RegistrationRateLimiter(window_seconds=600, max_per_domain=2, max_global=100)
+    monkeypatch.setattr(fediverse, '_registration_rate_limiter', limiter)
+    _stub_network(monkeypatch)
+
+    fediverse.register_app('example.social', 'https://honeycomb.example/callback', 'read:accounts')
+    fediverse.register_app('example.social', 'https://honeycomb.example/callback', 'read:accounts')
+    with pytest.raises(fediverse.FediverseError):
+        fediverse.register_app('example.social', 'https://honeycomb.example/callback', 'read:accounts')
+
+
+def test_register_app_per_domain_limit_does_not_affect_other_domains(monkeypatch):
+    limiter = fediverse._RegistrationRateLimiter(window_seconds=600, max_per_domain=1, max_global=100)
+    monkeypatch.setattr(fediverse, '_registration_rate_limiter', limiter)
+    _stub_network(monkeypatch)
+
+    fediverse.register_app('example.social', 'https://honeycomb.example/callback', 'read:accounts')
+    fediverse.register_app('other.social', 'https://honeycomb.example/callback', 'read:accounts')
+
+
+def test_register_app_enforces_global_rate_limit_across_domains(monkeypatch):
+    limiter = fediverse._RegistrationRateLimiter(window_seconds=600, max_per_domain=100, max_global=2)
+    monkeypatch.setattr(fediverse, '_registration_rate_limiter', limiter)
+    _stub_network(monkeypatch)
+
+    fediverse.register_app('a.example', 'https://honeycomb.example/callback', 'read:accounts')
+    fediverse.register_app('b.example', 'https://honeycomb.example/callback', 'read:accounts')
+    with pytest.raises(fediverse.FediverseError):
+        fediverse.register_app('c.example', 'https://honeycomb.example/callback', 'read:accounts')

--- a/tests/test_fediverse.py
+++ b/tests/test_fediverse.py
@@ -2,7 +2,7 @@ import socket
 
 import pytest
 
-from honeycomb.security import fediverse
+from honeycomb.security import fediverse, ratelimit
 
 
 def _fake_getaddrinfo(ip):
@@ -96,15 +96,15 @@ def test_states_match_false_for_missing():
 
 
 def test_choose_scope_prefers_profile_when_supported():
-    assert fediverse.choose_scope({'scopes_supported': ['read', 'profile']}) == 'profile'
+    assert fediverse.choose_scope({'scopes_supported': ['read', 'profile']}) == 'profile write:statuses'
 
 
 def test_choose_scope_falls_back_without_profile():
-    assert fediverse.choose_scope({'scopes_supported': ['read']}) == 'read:accounts'
+    assert fediverse.choose_scope({'scopes_supported': ['read']}) == 'read:accounts write:statuses'
 
 
 def test_choose_scope_falls_back_without_metadata():
-    assert fediverse.choose_scope(None) == 'read:accounts'
+    assert fediverse.choose_scope(None) == 'read:accounts write:statuses'
 
 
 def test_supports_pkce_true_when_s256_listed():
@@ -155,6 +155,194 @@ def test_account_to_drone_user_handles_nested_image_objects():
     assert user.background is None
 
 
+class _FakeJSONResponse:
+    def __init__(self, status_code, payload):
+        self.status_code = status_code
+        self._payload = payload
+        self.is_redirect = False
+        self.is_permanent_redirect = False
+
+    def json(self):
+        return self._payload
+
+
+def _stub_request(monkeypatch, response):
+    captured = {}
+
+    def fake_request(method, url, **kwargs):
+        captured['method'] = method
+        captured['url'] = url
+        captured['kwargs'] = kwargs
+        return response
+
+    monkeypatch.setattr(fediverse.requests, 'request', fake_request)
+    monkeypatch.setattr(fediverse, '_assert_public_host', lambda host: None)
+    return captured
+
+
+def test_discover_actor_url_sends_jrd_accept_header(monkeypatch):
+    """unam.social (Pleroma) da 400 sin este header exacto -- verificado en vivo."""
+    jrd = {
+        'subject': 'acct:tester@example.social',
+        'links': [
+            {'rel': 'self', 'type': 'application/activity+json', 'href': 'https://example.social/users/tester'},
+        ],
+    }
+    captured = _stub_request(monkeypatch, _FakeJSONResponse(200, jrd))
+    url = fediverse.discover_actor_url('tester', 'example.social')
+    assert url == 'https://example.social/users/tester'
+    assert captured['kwargs']['headers']['Accept'] == 'application/jrd+json'
+    assert captured['kwargs']['params'] == {'resource': 'acct:tester@example.social'}
+
+
+def test_discover_actor_url_returns_none_without_matching_link(monkeypatch):
+    jrd = {'links': [{'rel': 'self', 'type': 'text/html', 'href': 'https://example.social/@tester'}]}
+    _stub_request(monkeypatch, _FakeJSONResponse(200, jrd))
+    assert fediverse.discover_actor_url('tester', 'example.social') is None
+
+
+def test_discover_actor_url_returns_none_on_non_200(monkeypatch):
+    _stub_request(monkeypatch, _FakeJSONResponse(400, {}))
+    assert fediverse.discover_actor_url('tester', 'example.social') is None
+
+
+def test_discover_actor_url_returns_none_on_network_error(monkeypatch):
+    def fail(*a, **k):
+        raise fediverse.requests.RequestException('boom')
+    monkeypatch.setattr(fediverse.requests, 'request', fail)
+    monkeypatch.setattr(fediverse, '_assert_public_host', lambda host: None)
+    assert fediverse.discover_actor_url('tester', 'example.social') is None
+
+
+def test_fetch_actor_sends_activity_json_accept_header(monkeypatch):
+    actor = {'id': 'https://example.social/users/tester', 'preferredUsername': 'tester'}
+    captured = _stub_request(monkeypatch, _FakeJSONResponse(200, actor))
+    result = fediverse.fetch_actor('https://example.social/users/tester')
+    assert result == actor
+    assert captured['kwargs']['headers']['Accept'] == 'application/activity+json'
+
+
+def test_fetch_actor_returns_none_on_non_200(monkeypatch):
+    _stub_request(monkeypatch, _FakeJSONResponse(404, {}))
+    assert fediverse.fetch_actor('https://example.social/users/ghost') is None
+
+
+def test_actor_oauth_endpoints_reads_declared_endpoints():
+    actor = {
+        'endpoints': {
+            'oauthRegistrationEndpoint': 'https://example.social/apps',
+            'oauthAuthorizationEndpoint': 'https://example.social/authorize',
+            'oauthTokenEndpoint': 'https://example.social/token',
+            'sharedInbox': 'https://example.social/inbox',
+        },
+    }
+    assert fediverse.actor_oauth_endpoints(actor) == {
+        'registration': 'https://example.social/apps',
+        'authorization': 'https://example.social/authorize',
+        'token': 'https://example.social/token',
+    }
+
+
+def test_actor_oauth_endpoints_empty_when_actor_lacks_them():
+    """Caso mastodon.social: solo declara sharedInbox, sin extension oauth*."""
+    assert fediverse.actor_oauth_endpoints({'endpoints': {'sharedInbox': 'https://example.social/inbox'}}) == {}
+    assert fediverse.actor_oauth_endpoints(None) == {}
+    assert fediverse.actor_oauth_endpoints({}) == {}
+
+
+def test_actor_to_drone_user_maps_fields():
+    actor = {
+        'id': 'https://example.social/users/alice',
+        'preferredUsername': 'alice',
+        'name': 'Alice',
+        'icon': {'url': 'https://example.social/avatar.png'},
+        'image': {'url': 'https://example.social/header.png'},
+        'inbox': 'https://example.social/users/alice/inbox',
+        'outbox': 'https://example.social/users/alice/outbox',
+    }
+    user = fediverse.actor_to_drone_user('example.social', actor)
+    assert user.userid == 'https://example.social/users/alice'
+    assert user.display_name == 'Alice'
+    assert user.username == 'alice@example.social'
+    assert user.icon == 'https://example.social/avatar.png'
+    assert user.background == 'https://example.social/header.png'
+    assert user.actor_url == 'https://example.social/users/alice'
+    assert user.inbox == 'https://example.social/users/alice/inbox'
+    assert user.outbox == 'https://example.social/users/alice/outbox'
+
+
+def test_actor_to_drone_user_handles_null_icon_and_image():
+    """Caso real verificado en vivo: unam.social devuelve icon/image en null."""
+    actor = {
+        'id': 'https://unam.social/users/convida',
+        'preferredUsername': 'convida',
+        'name': 'Proyecto Convida',
+        'icon': None,
+        'image': None,
+        'inbox': 'https://unam.social/users/convida/inbox',
+        'outbox': 'https://unam.social/users/convida/outbox',
+    }
+    user = fediverse.actor_to_drone_user('unam.social', actor)
+    assert user.icon is None
+    assert user.background is None
+    assert user.display_name == 'Proyecto Convida'
+
+
+def test_actor_to_drone_user_falls_back_without_preferred_username():
+    actor = {'id': 'https://example.social/users/1'}
+    user = fediverse.actor_to_drone_user('example.social', actor)
+    assert user.username == 'example.social'
+    assert user.display_name == 'example.social'
+
+
+def test_register_app_uses_endpoint_override_when_given(monkeypatch):
+    captured = _stub_request(monkeypatch, _FakeJSONResponse(200, {'client_id': 'id', 'client_secret': 'secret'}))
+    fediverse.register_app(
+        'example.social', 'https://honeycomb.example/callback', 'read:accounts',
+        endpoint='https://example.social/custom/apps',
+    )
+    assert captured['url'] == 'https://example.social/custom/apps'
+
+
+def test_register_app_falls_back_to_mastodon_path_without_endpoint(monkeypatch):
+    captured = _stub_request(monkeypatch, _FakeJSONResponse(200, {'client_id': 'id', 'client_secret': 'secret'}))
+    fediverse.register_app('example.social', 'https://honeycomb.example/callback', 'read:accounts')
+    assert captured['url'] == 'https://example.social/api/v1/apps'
+
+
+def test_build_authorize_url_uses_endpoint_override_when_given():
+    url = fediverse.build_authorize_url(
+        'example.social', 'client-id', 'https://honeycomb.example/callback', 'state123', 'read:accounts',
+        endpoint='https://example.social/custom/authorize',
+    )
+    assert url.startswith('https://example.social/custom/authorize?')
+
+
+def test_build_authorize_url_falls_back_to_mastodon_path_without_endpoint():
+    url = fediverse.build_authorize_url(
+        'example.social', 'client-id', 'https://honeycomb.example/callback', 'state123', 'read:accounts',
+    )
+    assert url.startswith('https://example.social/oauth/authorize?')
+
+
+def test_exchange_code_uses_endpoint_override_when_given(monkeypatch):
+    captured = _stub_request(monkeypatch, _FakeJSONResponse(200, {'access_token': 'tok'}))
+    fediverse.exchange_code(
+        'example.social', 'client-id', 'secret', 'https://honeycomb.example/callback',
+        'code123', 'read:accounts', endpoint='https://example.social/custom/token',
+    )
+    assert captured['url'] == 'https://example.social/custom/token'
+
+
+def test_exchange_code_falls_back_to_mastodon_path_without_endpoint(monkeypatch):
+    captured = _stub_request(monkeypatch, _FakeJSONResponse(200, {'access_token': 'tok'}))
+    fediverse.exchange_code(
+        'example.social', 'client-id', 'secret', 'https://honeycomb.example/callback',
+        'code123', 'read:accounts',
+    )
+    assert captured['url'] == 'https://example.social/oauth/token'
+
+
 class _FakeAppResponse:
     status_code = 200
     is_redirect = False
@@ -170,7 +358,7 @@ def _stub_network(monkeypatch):
 
 
 def test_register_app_enforces_per_domain_rate_limit(monkeypatch):
-    limiter = fediverse._RegistrationRateLimiter(window_seconds=600, max_per_domain=2, max_global=100)
+    limiter = ratelimit.SlidingWindowLimiter(window_seconds=600, max_per_key=2, max_global=100)
     monkeypatch.setattr(fediverse, '_registration_rate_limiter', limiter)
     _stub_network(monkeypatch)
 
@@ -181,7 +369,7 @@ def test_register_app_enforces_per_domain_rate_limit(monkeypatch):
 
 
 def test_register_app_per_domain_limit_does_not_affect_other_domains(monkeypatch):
-    limiter = fediverse._RegistrationRateLimiter(window_seconds=600, max_per_domain=1, max_global=100)
+    limiter = ratelimit.SlidingWindowLimiter(window_seconds=600, max_per_key=1, max_global=100)
     monkeypatch.setattr(fediverse, '_registration_rate_limiter', limiter)
     _stub_network(monkeypatch)
 
@@ -190,7 +378,7 @@ def test_register_app_per_domain_limit_does_not_affect_other_domains(monkeypatch
 
 
 def test_register_app_enforces_global_rate_limit_across_domains(monkeypatch):
-    limiter = fediverse._RegistrationRateLimiter(window_seconds=600, max_per_domain=100, max_global=2)
+    limiter = ratelimit.SlidingWindowLimiter(window_seconds=600, max_per_key=100, max_global=2)
     monkeypatch.setattr(fediverse, '_registration_rate_limiter', limiter)
     _stub_network(monkeypatch)
 
@@ -198,3 +386,57 @@ def test_register_app_enforces_global_rate_limit_across_domains(monkeypatch):
     fediverse.register_app('b.example', 'https://honeycomb.example/callback', 'read:accounts')
     with pytest.raises(fediverse.FediverseError):
         fediverse.register_app('c.example', 'https://honeycomb.example/callback', 'read:accounts')
+
+
+def test_registration_rate_limiter_with_none_limits_never_blocks(monkeypatch):
+    """max_per_key/max_global en None (sin limite) -- el default cuando el .ini los deja en blanco."""
+    limiter = ratelimit.SlidingWindowLimiter(window_seconds=600, max_per_key=None, max_global=None)
+    monkeypatch.setattr(fediverse, '_registration_rate_limiter', limiter)
+    _stub_network(monkeypatch)
+
+    for _ in range(50):
+        fediverse.register_app('example.social', 'https://honeycomb.example/callback', 'read:accounts')
+
+
+@pytest.fixture
+def restore_rate_limiter():
+    """configure_registration_rate_limiter reasigna el modulo global de verdad
+    (no via monkeypatch); hay que devolverlo a como estaba para no filtrar
+    estado a otros tests."""
+    original = fediverse._registration_rate_limiter
+    yield
+    fediverse._registration_rate_limiter = original
+
+
+def test_configure_registration_rate_limiter_blank_settings_means_no_limit(restore_rate_limiter):
+    fediverse.configure_registration_rate_limiter({
+        'fediverse.registration_rate_window_seconds': '',
+        'fediverse.registration_rate_max_per_domain': '',
+        'fediverse.registration_rate_max_global': '',
+    })
+    limiter = fediverse._registration_rate_limiter
+    assert limiter.max_per_key is None
+    assert limiter.max_global is None
+    assert limiter.window_seconds == fediverse.DEFAULT_REGISTRATION_RATE_WINDOW_SECONDS
+
+
+def test_configure_registration_rate_limiter_reads_explicit_values(restore_rate_limiter):
+    fediverse.configure_registration_rate_limiter({
+        'fediverse.registration_rate_window_seconds': '120',
+        'fediverse.registration_rate_max_per_domain': '3',
+        'fediverse.registration_rate_max_global': '10',
+    })
+    limiter = fediverse._registration_rate_limiter
+    assert limiter.window_seconds == 120
+    assert limiter.max_per_key == 3
+    assert limiter.max_global == 10
+
+
+def test_configure_registration_rate_limiter_zero_means_no_limit(restore_rate_limiter):
+    fediverse.configure_registration_rate_limiter({
+        'fediverse.registration_rate_max_per_domain': '0',
+        'fediverse.registration_rate_max_global': '0',
+    })
+    limiter = fediverse._registration_rate_limiter
+    assert limiter.max_per_key is None
+    assert limiter.max_global is None

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -1,6 +1,6 @@
 def test_root(testapp):
     res = testapp.get('/', status=200)
-    assert b'Pyramid' in res.body
+    assert b'BeeHive' in res.body
 
 def test_notfound(testapp):
     res = testapp.get('/badurl', status=404)

--- a/tests/test_local_accounts.py
+++ b/tests/test_local_accounts.py
@@ -1,0 +1,202 @@
+import pytest
+
+from honeycomb.models import BeeHive
+from honeycomb.models.users import DroneUser
+from honeycomb.security import local_accounts
+
+ENABLED = {'honeycomb.local_accounts': 'true'}
+DISABLED = {'honeycomb.local_accounts': ''}
+
+
+@pytest.fixture(autouse=True)
+def restore_rate_limiters():
+    original_login = local_accounts._login_rate_limiter
+    original_registration = local_accounts._registration_rate_limiter
+    yield
+    local_accounts._login_rate_limiter = original_login
+    local_accounts._registration_rate_limiter = original_registration
+
+
+def test_register_creates_a_local_user():
+    hive = BeeHive()
+    user = local_accounts.register(hive, ENABLED, 'alice', 'correct horse battery staple')
+    assert user.userid.startswith('local:')
+    assert user.username == 'alice'
+    assert user.password_hash is not None
+
+
+def test_register_links_the_password_identity():
+    hive = BeeHive()
+    user = local_accounts.register(hive, ENABLED, 'alice', 'correct horse battery staple')
+    assert hive.resolve_identity('password:alice') == user.userid
+
+
+def test_register_raises_when_local_accounts_disabled():
+    hive = BeeHive()
+    with pytest.raises(local_accounts.LocalAuthError):
+        local_accounts.register(hive, DISABLED, 'alice', 'correct horse battery staple')
+
+
+def test_register_rejects_invalid_username():
+    hive = BeeHive()
+    with pytest.raises(local_accounts.LocalAuthError):
+        local_accounts.register(hive, ENABLED, 'a', 'correct horse battery staple')
+
+
+def test_register_rejects_short_password():
+    hive = BeeHive()
+    with pytest.raises(local_accounts.LocalAuthError):
+        local_accounts.register(hive, ENABLED, 'alice', 'short')
+
+
+def test_register_rejects_duplicate_username():
+    hive = BeeHive()
+    local_accounts.register(hive, ENABLED, 'alice', 'correct horse battery staple')
+    with pytest.raises(local_accounts.LocalAuthError):
+        local_accounts.register(hive, ENABLED, 'alice', 'a different password entirely')
+
+
+def test_register_username_is_case_insensitive_for_uniqueness():
+    hive = BeeHive()
+    local_accounts.register(hive, ENABLED, 'Alice', 'correct horse battery staple')
+    with pytest.raises(local_accounts.LocalAuthError):
+        local_accounts.register(hive, ENABLED, 'ALICE', 'a different password entirely')
+
+
+def test_authenticate_succeeds_with_correct_password():
+    hive = BeeHive()
+    created = local_accounts.register(hive, ENABLED, 'alice', 'correct horse battery staple')
+    authenticated = local_accounts.authenticate(hive, ENABLED, 'alice', 'correct horse battery staple')
+    assert authenticated.userid == created.userid
+
+
+def test_authenticate_raises_generic_error_for_unknown_user():
+    hive = BeeHive()
+    with pytest.raises(local_accounts.LocalAuthError):
+        local_accounts.authenticate(hive, ENABLED, 'nobody', 'whatever password')
+
+
+def test_authenticate_raises_generic_error_for_wrong_password():
+    hive = BeeHive()
+    local_accounts.register(hive, ENABLED, 'alice', 'correct horse battery staple')
+    with pytest.raises(local_accounts.LocalAuthError):
+        local_accounts.authenticate(hive, ENABLED, 'alice', 'wrong password entirely')
+
+
+def test_authenticate_unknown_user_and_wrong_password_give_the_same_message():
+    hive = BeeHive()
+    local_accounts.register(hive, ENABLED, 'alice', 'correct horse battery staple')
+
+    unknown_message = None
+    wrong_password_message = None
+    try:
+        local_accounts.authenticate(hive, ENABLED, 'nobody', 'whatever password')
+    except local_accounts.LocalAuthError as exc:
+        unknown_message = str(exc)
+    try:
+        local_accounts.authenticate(hive, ENABLED, 'alice', 'wrong password entirely')
+    except local_accounts.LocalAuthError as exc:
+        wrong_password_message = str(exc)
+
+    assert unknown_message == wrong_password_message
+
+
+def test_authenticate_raises_when_local_accounts_disabled():
+    hive = BeeHive()
+    local_accounts.register(hive, ENABLED, 'alice', 'correct horse battery staple')
+    with pytest.raises(local_accounts.LocalAuthError):
+        local_accounts.authenticate(hive, DISABLED, 'alice', 'correct horse battery staple')
+
+
+def test_link_password_adds_a_credential_to_an_existing_account():
+    hive = BeeHive()
+    fediverse_user = hive.upsert_user(DroneUser(
+        userid='https://unam.social/users/alice', display_name='Alice', username='alice@unam.social',
+    ))
+    local_accounts.link_password(hive, ENABLED, fediverse_user, 'alice', 'correct horse battery staple')
+
+    assert hive.resolve_identity('password:alice') == fediverse_user.userid
+    assert fediverse_user.password_hash is not None
+    assert local_accounts.authenticate(hive, ENABLED, 'alice', 'correct horse battery staple').userid == fediverse_user.userid
+
+
+def test_link_password_does_not_touch_the_display_username():
+    hive = BeeHive()
+    fediverse_user = hive.upsert_user(DroneUser(
+        userid='https://unam.social/users/alice', display_name='Alice', username='alice@unam.social',
+    ))
+    local_accounts.link_password(hive, ENABLED, fediverse_user, 'alicelocal', 'correct horse battery staple')
+    assert fediverse_user.username == 'alice@unam.social'
+
+
+def test_link_password_rejects_username_already_used_by_someone_else():
+    hive = BeeHive()
+    local_accounts.register(hive, ENABLED, 'alice', 'correct horse battery staple')
+    other_user = hive.upsert_user(DroneUser(userid='https://unam.social/users/bob', display_name='Bob', username='bob'))
+    with pytest.raises(local_accounts.LocalAuthError):
+        local_accounts.link_password(hive, ENABLED, other_user, 'alice', 'a different password entirely')
+
+
+def test_unlink_refuses_to_remove_the_last_credential():
+    hive = BeeHive()
+    user = local_accounts.register(hive, ENABLED, 'alice', 'correct horse battery staple')
+    with pytest.raises(local_accounts.LocalAuthError):
+        local_accounts.unlink(hive, user.userid, 'password:alice')
+
+
+def test_unlink_removes_a_non_last_credential_and_clears_the_password_hash():
+    hive = BeeHive()
+    user = local_accounts.register(hive, ENABLED, 'alice', 'correct horse battery staple')
+    hive.link_identity('fediverse:https://unam.social/users/alice', user.userid)
+
+    local_accounts.unlink(hive, user.userid, 'password:alice')
+
+    assert hive.resolve_identity('password:alice') is None
+    assert user.password_hash is None
+
+
+def test_unlink_raises_when_credential_not_linked_to_this_account():
+    hive = BeeHive()
+    user = local_accounts.register(hive, ENABLED, 'alice', 'correct horse battery staple')
+    with pytest.raises(local_accounts.LocalAuthError):
+        local_accounts.unlink(hive, user.userid, 'password:someone-else')
+
+
+def test_configure_rate_limiters_blank_settings_means_no_limit():
+    local_accounts.configure_rate_limiters({
+        'honeycomb.login_rate_window_seconds': '',
+        'honeycomb.login_rate_max_per_user': '',
+        'honeycomb.login_rate_max_global': '',
+        'honeycomb.registration_rate_max_global': '',
+    })
+    assert local_accounts._login_rate_limiter.max_per_key is None
+    assert local_accounts._login_rate_limiter.max_global is None
+    assert local_accounts._registration_rate_limiter.max_global is None
+
+
+def test_configure_rate_limiters_reads_explicit_values():
+    local_accounts.configure_rate_limiters({
+        'honeycomb.login_rate_window_seconds': '60',
+        'honeycomb.login_rate_max_per_user': '3',
+        'honeycomb.login_rate_max_global': '20',
+        'honeycomb.registration_rate_max_global': '5',
+    })
+    assert local_accounts._login_rate_limiter.window_seconds == 60
+    assert local_accounts._login_rate_limiter.max_per_key == 3
+    assert local_accounts._login_rate_limiter.max_global == 20
+    assert local_accounts._registration_rate_limiter.max_global == 5
+
+
+def test_login_rate_limit_blocks_after_max_attempts():
+    local_accounts.configure_rate_limiters({
+        'honeycomb.login_rate_window_seconds': '600',
+        'honeycomb.login_rate_max_per_user': '2',
+    })
+    hive = BeeHive()
+    local_accounts.register(hive, ENABLED, 'alice', 'correct horse battery staple')
+
+    for _ in range(2):
+        with pytest.raises(local_accounts.LocalAuthError):
+            local_accounts.authenticate(hive, ENABLED, 'alice', 'wrong password entirely')
+    with pytest.raises(local_accounts.LocalAuthError):
+        local_accounts.authenticate(hive, ENABLED, 'alice', 'correct horse battery staple')

--- a/tests/test_local_auth.py
+++ b/tests/test_local_auth.py
@@ -1,0 +1,190 @@
+# Nota: igual que en test_api_games.py, cada request de `testapp` corre en su
+# propia transaccion que se aborta al final (ver conftest.py). Los fixtures
+# register_as_local_user/login_as_local_user/login_as_fediverse_user usan
+# identity_bridge para simular persistencia entre requests; los flujos que
+# ademas tocan progreso (vincular y fusionar) usan game_data_bridge tambien.
+
+import urllib.parse
+
+
+def _redirects_to_error(location, path):
+    parts = urllib.parse.urlsplit(location)
+    return parts.path == path and 'error' in urllib.parse.parse_qs(parts.query)
+
+
+def test_register_page_renders_when_enabled(testapp):
+    page = testapp.get('/register', status=200)
+    form = page.forms['register-form']
+    assert 'username' in form.fields
+    assert 'password' in form.fields
+
+
+def test_register_page_shows_disabled_message(testapp, monkeypatch):
+    monkeypatch.setitem(testapp.app.registry.settings, 'honeycomb.local_accounts', '')
+    page = testapp.get('/register', status=200)
+    assert 'no esta habilitado' in page.text
+    assert 'register-form' not in page.forms
+
+
+def test_register_creates_account_and_logs_in(testapp, register_as_local_user):
+    register_as_local_user('alice', 'correct horse battery staple')
+    body = testapp.get('/api/v1/me', status=200).json
+    assert body['username'] == 'alice'
+
+
+def test_register_rejects_invalid_username(testapp):
+    page = testapp.get('/register', status=200)
+    csrf_token = page.forms['register-form']['csrf_token'].value
+    resp = testapp.post('/api/v1/auth/register', {
+        'username': 'a', 'password': 'correct horse battery staple', 'csrf_token': csrf_token,
+    }, status=303)
+    assert _redirects_to_error(resp.headers['Location'], '/register')
+
+
+def test_register_rejects_short_password(testapp):
+    page = testapp.get('/register', status=200)
+    csrf_token = page.forms['register-form']['csrf_token'].value
+    resp = testapp.post('/api/v1/auth/register', {
+        'username': 'alice', 'password': 'short', 'csrf_token': csrf_token,
+    }, status=303)
+    assert _redirects_to_error(resp.headers['Location'], '/register')
+
+
+def test_register_rejects_duplicate_username(testapp, register_as_local_user):
+    register_as_local_user('alice', 'correct horse battery staple')
+    testapp.reset()
+
+    page = testapp.get('/register', status=200)
+    csrf_token = page.forms['register-form']['csrf_token'].value
+    resp = testapp.post('/api/v1/auth/register', {
+        'username': 'alice', 'password': 'a different password entirely', 'csrf_token': csrf_token,
+    }, status=303)
+    assert _redirects_to_error(resp.headers['Location'], '/register')
+
+
+def test_register_disabled_returns_error(testapp, monkeypatch):
+    # csrf_token real (independiente de local_accounts) para que la peticion
+    # llegue al cuerpo de la vista en vez de que la rechace el check de CSRF.
+    csrf_token = testapp.get('/login', status=200).forms['fediverse-login-form']['csrf_token'].value
+    monkeypatch.setitem(testapp.app.registry.settings, 'honeycomb.local_accounts', '')
+
+    resp = testapp.post('/api/v1/auth/register', {
+        'username': 'alice', 'password': 'correct horse battery staple', 'csrf_token': csrf_token,
+    }, status=303)
+    assert _redirects_to_error(resp.headers['Location'], '/register')
+
+
+def test_local_login_succeeds_with_correct_credentials(testapp, register_as_local_user, login_as_local_user):
+    register_as_local_user('alice', 'correct horse battery staple')
+    testapp.reset()
+
+    login_as_local_user('alice', 'correct horse battery staple')
+    body = testapp.get('/api/v1/me', status=200).json
+    assert body['username'] == 'alice'
+
+
+def test_local_login_rejects_wrong_password(testapp, register_as_local_user, login_as_local_user):
+    register_as_local_user('alice', 'correct horse battery staple')
+    testapp.reset()
+
+    resp = login_as_local_user('alice', 'wrong password entirely')
+    assert _redirects_to_error(resp.headers['Location'], '/login')
+
+
+def test_local_login_unknown_and_wrong_password_give_the_same_message(testapp, register_as_local_user, login_as_local_user):
+    register_as_local_user('alice', 'correct horse battery staple')
+    testapp.reset()
+
+    unknown_resp = login_as_local_user('nobody', 'whatever password')
+    testapp.reset()
+    wrong_resp = login_as_local_user('alice', 'wrong password entirely')
+
+    unknown_error = urllib.parse.parse_qs(urllib.parse.urlsplit(unknown_resp.headers['Location']).query)['error']
+    wrong_error = urllib.parse.parse_qs(urllib.parse.urlsplit(wrong_resp.headers['Location']).query)['error']
+    assert unknown_error == wrong_error
+
+
+def test_account_page_requires_auth(testapp):
+    resp = testapp.get('/cuenta', status=303)
+    assert urllib.parse.urlsplit(resp.headers['Location']).path == '/login'
+
+
+def test_account_page_lists_the_password_identity_after_registering(testapp, register_as_local_user):
+    register_as_local_user('alice', 'correct horse battery staple')
+    page = testapp.get('/cuenta', status=200)
+    assert 'alice' in page.text
+    # Unica credencial: no debe ofrecer desvincularla.
+    assert 'unlink-form-1' not in page.forms
+
+
+def test_unlink_requires_auth(testapp):
+    csrf_token = testapp.get('/login', status=200).forms['fediverse-login-form']['csrf_token'].value
+    testapp.post('/api/v1/auth/unlink', {'identity_key': 'password:alice', 'csrf_token': csrf_token}, status=401)
+
+
+def test_unlink_refuses_to_remove_the_last_credential(testapp, register_as_local_user):
+    register_as_local_user('alice', 'correct horse battery staple')
+    page = testapp.get('/cuenta', status=200)
+    csrf_token = page.forms['link-fediverse-form']['csrf_token'].value
+
+    resp = testapp.post('/api/v1/auth/unlink', {
+        'identity_key': 'password:alice', 'csrf_token': csrf_token,
+    }, status=303)
+    assert _redirects_to_error(resp.headers['Location'], '/cuenta')
+
+
+def test_link_password_requires_auth(testapp):
+    csrf_token = testapp.get('/login', status=200).forms['fediverse-login-form']['csrf_token'].value
+    testapp.post('/api/v1/auth/link/password', {
+        'username': 'alice', 'password': 'correct horse battery staple', 'csrf_token': csrf_token,
+    }, status=401)
+
+
+def test_link_fediverse_to_local_account_merges_progress_and_lists_both_identities(
+    testapp, register_as_local_user, fediverse_stub, game_data_bridge,
+):
+    register_as_local_user('alice', 'correct horse battery staple')
+    # Progreso jugado ANTES de vincular, con la cuenta local.
+    testapp.post_json('/api/v1/sipping/node-a', {'stats': {'highscore': 5}}, status=200)
+
+    account_page = testapp.get('/cuenta', status=200)
+    csrf_token = account_page.forms['link-fediverse-form']['csrf_token'].value
+    start_resp = testapp.post('/api/v1/auth/login', {
+        'handle': fediverse_stub['handle'], 'csrf_token': csrf_token, 'next': '/cuenta',
+    }, status=303)
+    authorize_url = start_resp.headers['Location']
+    state = urllib.parse.parse_qs(urllib.parse.urlsplit(authorize_url).query)['state'][0]
+    callback_resp = testapp.get('/api/v1/auth/callback', {'code': 'fake-code', 'state': state}, status=303)
+    assert urllib.parse.urlsplit(callback_resp.headers['Location']).path == '/cuenta'
+
+    # El progreso jugado como cuenta local sigue disponible en la cuenta ya
+    # vinculada (se fusiono, no se perdio).
+    body = testapp.get('/api/v1/sipping/node-a', status=200).json
+    assert body['stats'] == {'highscore': 5}
+
+    account_page_after = testapp.get('/cuenta', status=200)
+    assert 'alice' in account_page_after.text
+    assert fediverse_stub['userid'] in account_page_after.text
+    # Ahora si hay mas de una credencial: debe ofrecer desvincular.
+    assert 'unlink-form-1' in account_page_after.forms
+
+
+def test_link_fediverse_already_linked_to_another_account_is_rejected(
+    testapp, register_as_local_user, login_as_fediverse_user, fediverse_stub,
+):
+    # La cuenta del Fediverso ya esta vinculada a si misma (login normal).
+    login_as_fediverse_user()
+    testapp.reset()
+
+    # Otra cuenta local intenta vincular ese mismo Fediverso.
+    register_as_local_user('bob', 'a different password entirely')
+    account_page = testapp.get('/cuenta', status=200)
+    csrf_token = account_page.forms['link-fediverse-form']['csrf_token'].value
+    start_resp = testapp.post('/api/v1/auth/login', {
+        'handle': fediverse_stub['handle'], 'csrf_token': csrf_token, 'next': '/cuenta',
+    }, status=303)
+    state = urllib.parse.parse_qs(urllib.parse.urlsplit(start_resp.headers['Location']).query)['state'][0]
+
+    callback_resp = testapp.get('/api/v1/auth/callback', {'code': 'fake-code', 'state': state}, status=303)
+    assert _redirects_to_error(callback_resp.headers['Location'], '/login')
+    assert 'vinculada a otra cuenta' in urllib.parse.unquote(callback_resp.headers['Location'])

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,65 @@
+from honeycomb.models import BeeHive, GameData
+
+
+def test_game_data_defaults():
+    record = GameData('user-1', 'node-1')
+    assert record.interactions == 0
+    assert record.stats == {}
+    assert record.preferences == {}
+    assert record.badges == []
+
+
+def test_game_data_register_interaction_increments():
+    record = GameData('user-1', 'node-1')
+    record.register_interaction()
+    record.register_interaction()
+    assert record.interactions == 2
+
+
+def test_game_data_merge_stats_keeps_previous_keys():
+    record = GameData('user-1', 'node-1')
+    record.merge_stats({'highscore': 10, 'level': 1})
+    record.merge_stats({'highscore': 20})
+    assert record.stats == {'highscore': 20, 'level': 1}
+
+
+def test_game_data_merge_stats_replace_clears_previous():
+    record = GameData('user-1', 'node-1')
+    record.merge_stats({'highscore': 10, 'level': 1})
+    record.merge_stats({'highscore': 20}, replace=True)
+    assert record.stats == {'highscore': 20}
+
+
+def test_game_data_to_dict_shape():
+    record = GameData('user-1', 'node-1')
+    data = record.to_dict()
+    assert set(data.keys()) == {
+        'userid', 'nodeid', 'interactions', 'stats',
+        'preferences', 'badges', 'first_seen', 'last_seen',
+    }
+
+
+def test_beehive_get_game_data_returns_none_without_create():
+    hive = BeeHive()
+    assert hive.get_game_data('user-1', 'node-1') is None
+
+
+def test_beehive_get_game_data_creates_and_persists_in_memory():
+    hive = BeeHive()
+    created = hive.get_game_data('user-1', 'node-1', create=True)
+    created.merge_stats({'highscore': 5})
+
+    fetched = hive.get_game_data('user-1', 'node-1')
+    assert fetched is created
+    assert fetched.stats == {'highscore': 5}
+
+
+def test_beehive_get_game_data_isolated_per_user_and_node():
+    hive = BeeHive()
+    a = hive.get_game_data('user-1', 'node-1', create=True)
+    b = hive.get_game_data('user-2', 'node-1', create=True)
+    c = hive.get_game_data('user-1', 'node-2', create=True)
+
+    a.merge_stats({'highscore': 1})
+    assert b.stats == {}
+    assert c.stats == {}

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -63,3 +63,217 @@ def test_beehive_get_game_data_isolated_per_user_and_node():
     a.merge_stats({'highscore': 1})
     assert b.stats == {}
     assert c.stats == {}
+
+
+def test_game_data_award_badge_adds_it():
+    record = GameData('user-1', 'node-1')
+    badge = record.award_badge('high-score-100', 'Cien puntos', icon='🏆')
+    assert badge.id == 'high-score-100'
+    assert badge.title == 'Cien puntos'
+    assert badge.icon == '🏆'
+    assert len(record.badges) == 1
+
+
+def test_game_data_award_badge_is_idempotent():
+    record = GameData('user-1', 'node-1')
+    first = record.award_badge('high-score-100', 'Cien puntos')
+    second = record.award_badge('high-score-100', 'Titulo distinto ignorado')
+    assert first is second
+    assert len(record.badges) == 1
+    assert record.badges[0].title == 'Cien puntos'
+
+
+def test_game_data_award_badge_allows_multiple_different_badges():
+    record = GameData('user-1', 'node-1')
+    record.award_badge('badge-a', 'A')
+    record.award_badge('badge-b', 'B')
+    assert {b.id for b in record.badges} == {'badge-a', 'badge-b'}
+
+
+def test_game_data_to_dict_serializes_badges():
+    record = GameData('user-1', 'node-1')
+    record.award_badge('high-score-100', 'Cien puntos', icon='🏆')
+    data = record.to_dict()
+    assert data['badges'] == [{
+        'id': 'high-score-100', 'title': 'Cien puntos', 'icon': '🏆',
+        'awarded_at': record.badges[0].awarded_at,
+    }]
+
+
+def test_beehive_iter_user_badges_empty_for_new_hive():
+    hive = BeeHive()
+    assert list(hive.iter_user_badges('user-1')) == []
+
+
+def test_beehive_iter_user_badges_collects_across_nodes():
+    hive = BeeHive()
+    record_a = hive.get_game_data('user-1', 'node-a', create=True)
+    record_a.award_badge('badge-a', 'A')
+    record_b = hive.get_game_data('user-1', 'node-b', create=True)
+    record_b.award_badge('badge-b', 'B')
+    hive.get_game_data('user-2', 'node-a', create=True).award_badge('other-user-badge', 'X')
+
+    results = list(hive.iter_user_badges('user-1'))
+    assert {(nodeid, badge.id) for nodeid, badge in results} == {('node-a', 'badge-a'), ('node-b', 'badge-b')}
+
+
+def test_beehive_resolve_identity_returns_none_when_unlinked():
+    hive = BeeHive()
+    assert hive.resolve_identity('password:alice') is None
+
+
+def test_beehive_link_then_resolve_identity():
+    hive = BeeHive()
+    hive.link_identity('password:alice', 'local:1234')
+    assert hive.resolve_identity('password:alice') == 'local:1234'
+
+
+def test_beehive_link_identity_overwrites_previous_mapping():
+    hive = BeeHive()
+    hive.link_identity('password:alice', 'local:1234')
+    hive.link_identity('password:alice', 'local:5678')
+    assert hive.resolve_identity('password:alice') == 'local:5678'
+
+
+def test_beehive_unlink_identity_removes_it():
+    hive = BeeHive()
+    hive.link_identity('password:alice', 'local:1234')
+    hive.unlink_identity('password:alice')
+    assert hive.resolve_identity('password:alice') is None
+
+
+def test_beehive_unlink_identity_is_safe_when_absent():
+    hive = BeeHive()
+    hive.unlink_identity('password:never-linked')
+
+
+def test_beehive_iter_identities_collects_all_credentials_for_a_userid():
+    hive = BeeHive()
+    hive.link_identity('password:alice', 'local:1234')
+    hive.link_identity('fediverse:https://unam.social/users/alice', 'local:1234')
+    hive.link_identity('password:bob', 'local:9999')
+
+    assert set(hive.iter_identities('local:1234')) == {
+        'password:alice', 'fediverse:https://unam.social/users/alice',
+    }
+    assert set(hive.iter_identities('local:9999')) == {'password:bob'}
+    assert set(hive.iter_identities('local:nobody')) == set()
+
+
+def test_merge_game_data_is_noop_for_same_userid():
+    hive = BeeHive()
+    record = hive.get_game_data('user-1', 'node-a', create=True)
+    record.register_interaction()
+    hive.merge_game_data('user-1', 'user-1')
+    assert hive.get_game_data('user-1', 'node-a').interactions == 1
+
+
+def test_merge_game_data_is_noop_when_secondary_has_no_data():
+    hive = BeeHive()
+    hive.get_game_data('into-user', 'node-a', create=True)
+    hive.merge_game_data('from-user', 'into-user')
+    assert hive.get_game_data('from-user', 'node-a') is None
+
+
+def test_merge_game_data_copies_node_only_present_in_secondary():
+    hive = BeeHive()
+    source = hive.get_game_data('from-user', 'node-a', create=True)
+    source.register_interaction()
+    source.merge_stats({'highscore': 10})
+    source.award_badge('badge-a', 'A')
+
+    hive.merge_game_data('from-user', 'into-user')
+
+    merged = hive.get_game_data('into-user', 'node-a')
+    assert merged is not None
+    assert merged.userid == 'into-user'
+    assert merged.interactions == 1
+    assert merged.stats == {'highscore': 10}
+    assert {b.id for b in merged.badges} == {'badge-a'}
+
+
+def test_merge_game_data_leaves_the_original_bucket_intact():
+    hive = BeeHive()
+    source = hive.get_game_data('from-user', 'node-a', create=True)
+    source.register_interaction()
+
+    hive.merge_game_data('from-user', 'into-user')
+
+    original = hive.get_game_data('from-user', 'node-a')
+    assert original is not None
+    assert original.interactions == 1
+    assert original.userid == 'from-user'
+
+
+def test_merge_game_data_unions_badges_without_duplicating_shared_ones():
+    hive = BeeHive()
+    source = hive.get_game_data('from-user', 'node-a', create=True)
+    source.award_badge('shared-badge', 'Compartido')
+    source.award_badge('only-in-source', 'Solo en origen')
+
+    target = hive.get_game_data('into-user', 'node-a', create=True)
+    target.award_badge('shared-badge', 'Compartido (destino)')
+    target_shared_awarded_at = target.badges[0].awarded_at
+
+    hive.merge_game_data('from-user', 'into-user')
+
+    merged = hive.get_game_data('into-user', 'node-a')
+    assert {b.id for b in merged.badges} == {'shared-badge', 'only-in-source'}
+    # Cuando ambos lados ya tienen el mismo badge_id, gana el que ya tenia
+    # into_userid -- no se sobreescribe con la copia de from_userid.
+    shared = next(b for b in merged.badges if b.id == 'shared-badge')
+    assert shared.title == 'Compartido (destino)'
+    assert shared.awarded_at == target_shared_awarded_at
+
+
+def test_merge_game_data_sums_interactions_when_both_have_the_node():
+    hive = BeeHive()
+    source = hive.get_game_data('from-user', 'node-a', create=True)
+    source.register_interaction()
+    source.register_interaction()
+    target = hive.get_game_data('into-user', 'node-a', create=True)
+    target.register_interaction()
+
+    hive.merge_game_data('from-user', 'into-user')
+
+    assert hive.get_game_data('into-user', 'node-a').interactions == 3
+
+
+def test_merge_game_data_keeps_primary_stats_and_preferences_on_conflict():
+    hive = BeeHive()
+    source = hive.get_game_data('from-user', 'node-a', create=True)
+    source.merge_stats({'highscore': 999})
+    target = hive.get_game_data('into-user', 'node-a', create=True)
+    target.merge_stats({'highscore': 5})
+
+    hive.merge_game_data('from-user', 'into-user')
+
+    assert hive.get_game_data('into-user', 'node-a').stats == {'highscore': 5}
+
+
+def test_merge_game_data_takes_min_first_seen_and_max_last_seen():
+    hive = BeeHive()
+    source = hive.get_game_data('from-user', 'node-a', create=True)
+    source.first_seen = '2020-01-01T00:00:00+00:00'
+    source.last_seen = '2020-01-01T00:00:00+00:00'
+    target = hive.get_game_data('into-user', 'node-a', create=True)
+    target.first_seen = '2025-01-01T00:00:00+00:00'
+    target.last_seen = '2025-06-01T00:00:00+00:00'
+
+    hive.merge_game_data('from-user', 'into-user')
+
+    merged = hive.get_game_data('into-user', 'node-a')
+    assert merged.first_seen == '2020-01-01T00:00:00+00:00'
+    assert merged.last_seen == '2025-06-01T00:00:00+00:00'
+
+
+def test_merge_game_data_covers_multiple_nodes_independently():
+    hive = BeeHive()
+    hive.get_game_data('from-user', 'node-a', create=True).award_badge('a', 'A')
+    hive.get_game_data('from-user', 'node-b', create=True).award_badge('b', 'B')
+    hive.get_game_data('into-user', 'node-b', create=True).award_badge('existing', 'Existente')
+
+    hive.merge_game_data('from-user', 'into-user')
+
+    assert {b.id for b in hive.get_game_data('into-user', 'node-a').badges} == {'a'}
+    assert {b.id for b in hive.get_game_data('into-user', 'node-b').badges} == {'existing', 'b'}

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -1,0 +1,25 @@
+EXPECTED_OPERATION_IDS = {
+    ('/api/v1/honeycombs', 'get'): 'listHoneycombs',
+    ('/api/v1/honeycombs/{name}', 'get'): 'getHoneycomb',
+    ('/api/v1/node/{node_id}', 'get'): 'getNode',
+    ('/api/v1/me', 'get'): 'getMe',
+    ('/api/v1/drones/{userid}', 'get'): 'getDrone',
+    ('/api/v1/userid', 'get'): 'getUserId',
+    ('/api/v1/sipping/{nodeid}', 'get'): 'getSippingData',
+    ('/api/v1/sipping/{nodeid}', 'post'): 'saveSippingData',
+}
+
+
+def test_openapi_spec_available_without_auth(testapp):
+    body = testapp.get('/openapi/openapi.json', status=200).json
+    assert body['openapi'].startswith('3.')
+
+
+def test_openapi_spec_lists_expected_operations(testapp):
+    body = testapp.get('/openapi/openapi.json', status=200).json
+    found = {
+        (path, method): op['operationId']
+        for path, methods in body['paths'].items()
+        for method, op in methods.items()
+    }
+    assert found == EXPECTED_OPERATION_IDS

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -7,6 +7,9 @@ EXPECTED_OPERATION_IDS = {
     ('/api/v1/userid', 'get'): 'getUserId',
     ('/api/v1/sipping/{nodeid}', 'get'): 'getSippingData',
     ('/api/v1/sipping/{nodeid}', 'post'): 'saveSippingData',
+    ('/api/v1/sipping/{nodeid}/badges', 'post'): 'awardBadge',
+    ('/api/v1/achievements', 'get'): 'getAchievements',
+    ('/api/v1/share', 'post'): 'shareAchievement',
 }
 
 

--- a/tests/test_passwords.py
+++ b/tests/test_passwords.py
@@ -1,0 +1,102 @@
+import pytest
+
+from honeycomb.security import passwords
+
+
+def test_hash_then_verify_roundtrip():
+    stored = passwords.hash_password('correct horse battery staple')
+    assert passwords.verify_password('correct horse battery staple', stored) is True
+
+
+def test_verify_rejects_wrong_password():
+    stored = passwords.hash_password('correct horse battery staple')
+    assert passwords.verify_password('wrong password', stored) is False
+
+
+def test_hash_is_salted_differently_each_time():
+    a = passwords.hash_password('same password')
+    b = passwords.hash_password('same password')
+    assert a != b
+    assert passwords.verify_password('same password', a) is True
+    assert passwords.verify_password('same password', b) is True
+
+
+def test_stored_hash_is_self_describing():
+    stored = passwords.hash_password('correct horse battery staple')
+    scheme, params, salt_b64, digest_b64 = stored.split('$')
+    assert scheme == 'scrypt'
+    assert 'n=' in params and 'r=' in params and 'p=' in params
+
+
+def test_verify_returns_false_on_garbage_input():
+    assert passwords.verify_password('anything', 'not-a-valid-hash') is False
+    assert passwords.verify_password('anything', '') is False
+    assert passwords.verify_password('anything', 'scrypt$garbage$x$y') is False
+
+
+def test_verify_returns_false_for_unknown_scheme():
+    stored = passwords.hash_password('correct horse battery staple')
+    fake = stored.replace('scrypt$', 'md5$')
+    assert passwords.verify_password('correct horse battery staple', fake) is False
+
+
+def test_validate_password_accepts_long_enough():
+    passwords.validate_password('correct horse battery staple')
+
+
+def test_validate_password_rejects_short():
+    with pytest.raises(passwords.CredentialError):
+        passwords.validate_password('short')
+
+
+def test_validate_password_respects_custom_min_length():
+    passwords.validate_password('12345', min_length=5)
+    with pytest.raises(passwords.CredentialError):
+        passwords.validate_password('1234', min_length=5)
+
+
+def test_validate_password_rejects_empty():
+    with pytest.raises(passwords.CredentialError):
+        passwords.validate_password('')
+    with pytest.raises(passwords.CredentialError):
+        passwords.validate_password(None)
+
+
+def test_normalize_username_lowercases_and_trims():
+    assert passwords.normalize_username('  Levi_Iparrea  ') == 'levi_iparrea'
+
+
+def test_normalize_username_rejects_too_short():
+    with pytest.raises(passwords.CredentialError):
+        passwords.normalize_username('ab')
+
+
+def test_normalize_username_rejects_too_long():
+    with pytest.raises(passwords.CredentialError):
+        passwords.normalize_username('a' * 33)
+
+
+def test_normalize_username_rejects_at_sign():
+    with pytest.raises(passwords.CredentialError):
+        passwords.normalize_username('levi@unam.social')
+
+
+def test_normalize_username_rejects_colon():
+    with pytest.raises(passwords.CredentialError):
+        passwords.normalize_username('fediverse:levi')
+
+
+def test_normalize_username_rejects_slash():
+    with pytest.raises(passwords.CredentialError):
+        passwords.normalize_username('https://unam.social/users/levi')
+
+
+def test_normalize_username_rejects_blank():
+    with pytest.raises(passwords.CredentialError):
+        passwords.normalize_username('')
+    with pytest.raises(passwords.CredentialError):
+        passwords.normalize_username(None)
+
+
+def test_normalize_username_accepts_hyphen_and_underscore():
+    assert passwords.normalize_username('levi-iparrea_2') == 'levi-iparrea_2'

--- a/tests/test_ratelimit.py
+++ b/tests/test_ratelimit.py
@@ -1,0 +1,69 @@
+import pytest
+
+from honeycomb.security import ratelimit
+
+
+def test_sliding_window_limiter_allows_up_to_the_per_key_limit():
+    limiter = ratelimit.SlidingWindowLimiter(window_seconds=600, max_per_key=2, max_global=100)
+    limiter.check_and_record('alice')
+    limiter.check_and_record('alice')
+    with pytest.raises(ratelimit.RateLimitError) as excinfo:
+        limiter.check_and_record('alice')
+    assert excinfo.value.scope == 'key'
+
+
+def test_sliding_window_limiter_per_key_limit_does_not_affect_other_keys():
+    limiter = ratelimit.SlidingWindowLimiter(window_seconds=600, max_per_key=1, max_global=100)
+    limiter.check_and_record('alice')
+    limiter.check_and_record('bob')
+
+
+def test_sliding_window_limiter_enforces_global_limit_across_keys():
+    limiter = ratelimit.SlidingWindowLimiter(window_seconds=600, max_per_key=100, max_global=2)
+    limiter.check_and_record('alice')
+    limiter.check_and_record('bob')
+    with pytest.raises(ratelimit.RateLimitError) as excinfo:
+        limiter.check_and_record('carol')
+    assert excinfo.value.scope == 'global'
+
+
+def test_sliding_window_limiter_with_none_limits_never_blocks():
+    limiter = ratelimit.SlidingWindowLimiter(window_seconds=600, max_per_key=None, max_global=None)
+    for _ in range(50):
+        limiter.check_and_record('alice')
+
+
+def test_positive_int_setting_falls_back_to_default_when_blank():
+    assert ratelimit.positive_int_setting({}, 'x', 42) == 42
+    assert ratelimit.positive_int_setting({'x': ''}, 'x', 42) == 42
+
+
+def test_positive_int_setting_falls_back_to_default_when_not_a_number():
+    assert ratelimit.positive_int_setting({'x': 'garbage'}, 'x', 42) == 42
+
+
+def test_positive_int_setting_falls_back_to_default_when_not_positive():
+    assert ratelimit.positive_int_setting({'x': '0'}, 'x', 42) == 42
+    assert ratelimit.positive_int_setting({'x': '-5'}, 'x', 42) == 42
+
+
+def test_positive_int_setting_reads_explicit_value():
+    assert ratelimit.positive_int_setting({'x': '120'}, 'x', 42) == 120
+
+
+def test_limit_setting_or_none_is_none_when_blank_or_absent():
+    assert ratelimit.limit_setting_or_none({}, 'x') is None
+    assert ratelimit.limit_setting_or_none({'x': ''}, 'x') is None
+
+
+def test_limit_setting_or_none_is_none_when_zero_or_negative():
+    assert ratelimit.limit_setting_or_none({'x': '0'}, 'x') is None
+    assert ratelimit.limit_setting_or_none({'x': '-1'}, 'x') is None
+
+
+def test_limit_setting_or_none_is_none_when_garbage():
+    assert ratelimit.limit_setting_or_none({'x': 'garbage'}, 'x') is None
+
+
+def test_limit_setting_or_none_reads_explicit_value():
+    assert ratelimit.limit_setting_or_none({'x': '5'}, 'x') == 5

--- a/tests/test_tokenstore.py
+++ b/tests/test_tokenstore.py
@@ -1,0 +1,72 @@
+import pytest
+
+from honeycomb.security import tokenstore
+
+REAL_KEY = tokenstore.generate_key()
+
+
+def test_generate_key_produces_valid_fernet_key():
+    key = tokenstore.generate_key()
+    # No debe tronar al usarse para construir un Fernet real.
+    tokenstore.encrypt_token({'honeycomb.token_encryption_key': key}, 'sometoken')
+
+
+def test_is_configured_false_when_key_blank():
+    assert tokenstore.is_configured({'honeycomb.token_encryption_key': ''}) is False
+    assert tokenstore.is_configured({}) is False
+
+
+def test_is_configured_true_when_key_present():
+    assert tokenstore.is_configured({'honeycomb.token_encryption_key': REAL_KEY}) is True
+
+
+def test_encrypt_token_returns_none_without_key():
+    settings = {'honeycomb.token_encryption_key': ''}
+    assert tokenstore.encrypt_token(settings, 'my-access-token') is None
+
+
+def test_encrypt_token_returns_none_for_empty_token():
+    settings = {'honeycomb.token_encryption_key': REAL_KEY}
+    assert tokenstore.encrypt_token(settings, '') is None
+    assert tokenstore.encrypt_token(settings, None) is None
+
+
+def test_encrypt_then_decrypt_roundtrip():
+    settings = {'honeycomb.token_encryption_key': REAL_KEY}
+    encrypted = tokenstore.encrypt_token(settings, 'my-access-token')
+    assert encrypted is not None
+    assert encrypted != 'my-access-token'
+    assert tokenstore.decrypt_token(settings, encrypted) == 'my-access-token'
+
+
+def test_decrypt_token_returns_none_for_empty_input():
+    settings = {'honeycomb.token_encryption_key': REAL_KEY}
+    assert tokenstore.decrypt_token(settings, None) is None
+    assert tokenstore.decrypt_token(settings, '') is None
+
+
+def test_decrypt_token_raises_without_key_configured():
+    settings = {'honeycomb.token_encryption_key': ''}
+    with pytest.raises(tokenstore.TokenStoreError):
+        tokenstore.decrypt_token(settings, 'gAAAAA-some-fake-ciphertext')
+
+
+def test_decrypt_token_raises_on_invalid_ciphertext():
+    settings = {'honeycomb.token_encryption_key': REAL_KEY}
+    with pytest.raises(tokenstore.TokenStoreError):
+        tokenstore.decrypt_token(settings, 'not-a-real-fernet-token')
+
+
+def test_decrypt_token_raises_when_key_rotated():
+    original_settings = {'honeycomb.token_encryption_key': REAL_KEY}
+    encrypted = tokenstore.encrypt_token(original_settings, 'my-access-token')
+
+    rotated_settings = {'honeycomb.token_encryption_key': tokenstore.generate_key()}
+    with pytest.raises(tokenstore.TokenStoreError):
+        tokenstore.decrypt_token(rotated_settings, encrypted)
+
+
+def test_fernet_raises_clear_error_on_malformed_key():
+    settings = {'honeycomb.token_encryption_key': 'not-a-valid-fernet-key'}
+    with pytest.raises(tokenstore.TokenStoreError):
+        tokenstore.encrypt_token(settings, 'my-access-token')

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,11 +1,14 @@
-from honeycomb.views.default import my_view
+from honeycomb.models import BeeHive
+from honeycomb.views.default import beehive_view
 from honeycomb.views.notfound import notfound_view
 
 
-def test_my_view(app_request):
-    info = my_view(app_request)
+def test_beehive_view(app_request):
+    context = BeeHive()
+    info = beehive_view(context, app_request)
     assert app_request.response.status_int == 200
-    assert info['project'] == 'Honeycomb'
+    assert info['project'] == 'BeeHive Project'
+    assert info['honeycombs'] == []
 
 def test_notfound_view(app_request):
     info = notfound_view(app_request)

--- a/uv.lock
+++ b/uv.lock
@@ -294,6 +294,56 @@ wheels = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "50.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/41/6cbdcf9142d00fe82836fbb51e503e58088575cf7a0fe1dbff6695bf0840/cryptography-50.0.0.tar.gz", hash = "sha256:eeac2acb5a20ed25e0ad6d1df9891a520b78b404266b6d11778f25d5d691a6c9", size = 880201, upload-time = "2026-07-31T14:25:10.11Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/5c/59086b4aac5e879d38ddbcf74e4be7ade89cebc3eb199a55da998c3bb46a/cryptography-50.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:031e2d5dd4bb9caa3ca9c82e5a197fd8ae680232cee62603d1a813f3f07e3d03", size = 4001252, upload-time = "2026-07-31T14:23:33.331Z" },
+    { url = "https://files.pythonhosted.org/packages/57/ef/8f2df13c7216bcad3e1c74e07f6e193d93e998e114f524a53877c9af27ad/cryptography-50.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fd9192b7b70c573d7f214eb1ae35e00d359f6f5e4b27c7e21e30de1fc6204645", size = 4719554, upload-time = "2026-07-31T14:23:35.611Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/41/029086c34d91052fc3b88bcc8056f709a7c915c7a23b235a54eb800b1c97/cryptography-50.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:06a32a980526a6ab9a4b9bf8f7385800791e2bb960903cb6b530e4817509a3b7", size = 4702130, upload-time = "2026-07-31T14:23:37.635Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/ff/b6ce0954962e7f7b969f850a883744197bb3910bdfd7b6da162eab7d9f68/cryptography-50.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a1b30560f2acc95aa8b2e06e716a13dbfc97314747b80d9707e307f77b40d6b3", size = 4725244, upload-time = "2026-07-31T14:23:39.471Z" },
+    { url = "https://files.pythonhosted.org/packages/06/1e/63a1027cb7fec360a182208e1b7767d5aa1fe57be3d6aa856e69a321edc0/cryptography-50.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:8d89f3976b10b4ce31118de72329025f70d2c6ead14a8217c5514dd2c6d5a78f", size = 5342265, upload-time = "2026-07-31T14:23:41.286Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/72/a1116d683a6d7ece94590013882515de087edf9ef0e6292aae615a44df73/cryptography-50.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:b42a28c1844fd9de8f3f7d540e36b66f3a9c83fceac7170ebc7a6a19edd9dcae", size = 4734609, upload-time = "2026-07-31T14:23:43.139Z" },
+    { url = "https://files.pythonhosted.org/packages/15/37/36a9c479bbe49acea2636c7fd3360d20f7b7e079c300352011c44850b181/cryptography-50.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:900131fafd8aead39ac7dd3a7e833be754c17a95cfd91221636949fe4eb0aa8a", size = 4356517, upload-time = "2026-07-31T14:23:44.939Z" },
+    { url = "https://files.pythonhosted.org/packages/32/98/8a151d64367204cbc63ec65d37502f1d9c53cf4bfc6ec3c532614dbec60d/cryptography-50.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:07949c449a1abcf60d1ee6e88956d89404c7df3c8258f46589e912988e551987", size = 4724529, upload-time = "2026-07-31T14:23:46.93Z" },
+    { url = "https://files.pythonhosted.org/packages/22/f6/ec13b470172126464a86bf54d2294a46d29837fc51ba3e45d4047946fb5e/cryptography-50.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:f89831ef99dd7dd169ab06d63a831adb9e20a87aac6d380266bbda5823349169", size = 5299852, upload-time = "2026-07-31T14:23:48.851Z" },
+    { url = "https://files.pythonhosted.org/packages/da/3a/f05e32c99d440c9bb891ea0e36c9091891e36be5a9a87ab2ee6ea20729f6/cryptography-50.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:82148ec5bddac30b51a5b3c1945075f896fa022cb93f8e4a01e9f6ee95292c5f", size = 4734462, upload-time = "2026-07-31T14:23:50.861Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/dc/bd72b26be8953f80625f63151efd38eee71c76ca6cf591c08ff34615a79e/cryptography-50.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1489e263a8048bb8b6a8bac662eb2d402ea5d2b7b4699b72f385f1e2772db105", size = 4852708, upload-time = "2026-07-31T14:23:52.715Z" },
+    { url = "https://files.pythonhosted.org/packages/27/20/c930314a2ab476d15dec966ec87e2e9637bb02b06106b12c0396c57bb603/cryptography-50.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7cec5b856506da6defb290f30c9ee687d5f5e8cb0bd3f6459dde43b0b4fa40ef", size = 5004179, upload-time = "2026-07-31T14:23:54.887Z" },
+    { url = "https://files.pythonhosted.org/packages/32/2e/c9db68a0c4bfa28e310707527c0ee3a2bd254104d2e02e68f368e197aa4c/cryptography-50.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:bd1c592e4d5974f0d08d4888e432157adba757c66da0246918e43677fafa2d30", size = 3840395, upload-time = "2026-07-31T14:23:56.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/fb/951032a3bf22a5697c83183fb6294a4843772947a70e616c57b3ff5f522e/cryptography-50.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:49e7d93abdbd2990caced757e5fade25302f719c3c8fb6e6fff2dde98999fc41", size = 3989258, upload-time = "2026-07-31T14:23:58.881Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/67/91eb047e69c5e845f2f14b8a2e4a1aab0f283cb885531e9e22c8adb176bc/cryptography-50.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:19736989797678c6af1e55cd49055cdbcb55d8f6b5583ac5335f933aba9101dc", size = 4700648, upload-time = "2026-07-31T14:24:00.702Z" },
+    { url = "https://files.pythonhosted.org/packages/30/82/85f0f7425c856b9f96459411eb12e74ef72df9caf6f8f15bf23a33ff131f/cryptography-50.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:80b63928fa35083b33966ce1efb70e5b9607181e49dcd1c22c8c005e319f667f", size = 4682442, upload-time = "2026-07-31T14:24:02.538Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/28/b555a365adff1cca2fbe7b9e487d68a40de6bc67ff2cb587473eb43de0e7/cryptography-50.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:d58c3db7cd6eed54e6c06744db55456b65ebd7492ddeae9c1e93cfca7aa857d3", size = 4707596, upload-time = "2026-07-31T14:24:04.394Z" },
+    { url = "https://files.pythonhosted.org/packages/72/d8/f52538140cc719df62a01cf87d1c7142318d235817109d6f4054d7c352d6/cryptography-50.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:df2a58a472f332225671c35b0a830208b86d004f82baa8530fa3782c85646533", size = 5314552, upload-time = "2026-07-31T14:24:06.31Z" },
+    { url = "https://files.pythonhosted.org/packages/38/14/6120e5bd7c5aa022ad15424ba4d5c5269d0d9448ed4d55e492ea91e3c1c4/cryptography-50.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:11b74db56cdbe3cdee6e3f6982ecb70334fa10dce99ed58bf7894aaaa3b2a037", size = 4717113, upload-time = "2026-07-31T14:24:08.349Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/71/190bf38c3ee2e0f8efc9860ae100c9df4169742eef274b91e7aa1cb133b9/cryptography-50.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f59e38625469987d7ef6d495323c55e7db6c212eaf6112267e0d3b565a2e9c9f", size = 4338580, upload-time = "2026-07-31T14:24:10.227Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/63/504ccfbbe61fd8aa983f7f146399cdf034c72c2fc55f5b2dfdcdcdb20c99/cryptography-50.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ecfed7367f965a0328cfbdd70da860f15441f002f613185668c6e6ebf5a0ac11", size = 4707038, upload-time = "2026-07-31T14:24:12.169Z" },
+    { url = "https://files.pythonhosted.org/packages/01/77/2cf79bbfc4d12ca106437a6e170d6aaa01a373e93093118aaaef0e801bd4/cryptography-50.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:9aa87839c383bdbab6ef865787a1fb877af8dd03464c4400322726feaaadfc6d", size = 5273110, upload-time = "2026-07-31T14:24:14.38Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/45/8aae2972c520145377ea3559a605a899bebe227bf070b33cdb445929a9b9/cryptography-50.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:6ba6a53445bd3cfa809ef3ef5f1589aa6ba08784a1d962bf47d0940e871dab1c", size = 4716439, upload-time = "2026-07-31T14:24:16.415Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/20/4fe50b619a48c2525cc46e2dbc1ac490708d704be5d467bdaac6dc955682/cryptography-50.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3f5735ffe4996d28b809371756219f5354864902a3b9e7c0b9ee87041209fc9c", size = 4837383, upload-time = "2026-07-31T14:24:18.553Z" },
+    { url = "https://files.pythonhosted.org/packages/92/91/3a31366e183343d3703f8995c095f5734676bd6938118047e50fcf279eb4/cryptography-50.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:1b4a266766514614f8aa60416e71f2fc6e575d36e7bdc90f644fadb2f4b75b95", size = 4985772, upload-time = "2026-07-31T14:24:20.385Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9a/02ffe35b2853d121689871eb5dce862092562b3a1ed5cc98f1aaed441506/cryptography-50.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:12b9c6996425c76ea6c457ace4f3073e715b8c545add07cd1a8f3a4f90691269", size = 3816291, upload-time = "2026-07-31T14:24:22.125Z" },
+    { url = "https://files.pythonhosted.org/packages/03/37/73d005be173aff344af30e9fd2a576575cb2391a7101d9cd3842e1fa8cce/cryptography-50.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ccdc4a71a4dabae05de219404f9f4abc38e3b58422177ff93d0da05967dafa07", size = 4036009, upload-time = "2026-07-31T14:24:24.122Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c6/7a6202a534e32103a285b7834a120869557fe198d51d7cfe59754c8bda9c/cryptography-50.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:910e1d2668e7de9648f2bcee30e180db2a6b15c30f887d7c4c93ddf96e3992e3", size = 4745252, upload-time = "2026-07-31T14:24:26.118Z" },
+    { url = "https://files.pythonhosted.org/packages/85/4f/0fa8c2f4428198f15d9ff8d63400e27afbf94ce833f6108da1eb3753f945/cryptography-50.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a91296cb61e8df6f86d0c19cc4068228da256bf59bf86049fbd821084565327f", size = 4728939, upload-time = "2026-07-31T14:24:27.994Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/63/54dd723490ba2dc09b299682c10b38db38f159728bcaae8c591b8af2f22d/cryptography-50.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e722f16708d854fe924790e051061f6704a472c3bac347b6fd88033ea8dd0dc5", size = 4748483, upload-time = "2026-07-31T14:24:30.254Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/dd/7c77d26285cc7f6991efce64a0f5b4f9383bfa5dd8c5033003eaf7db4cdb/cryptography-50.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:d764dcf130c428ef66786f866dd750f53182bc608813489915e9fc106bb0c82f", size = 5367599, upload-time = "2026-07-31T14:24:32.457Z" },
+    { url = "https://files.pythonhosted.org/packages/46/c9/f60aed34c013f317f92817b6c171c2d22a78270fa41109bd4b08af26b194/cryptography-50.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:105110f43a471dbd0060b9c9516cb8a6a79233631a04cc2ba16f28323ac6e025", size = 4762647, upload-time = "2026-07-31T14:24:34.599Z" },
+    { url = "https://files.pythonhosted.org/packages/be/f3/f9a0173b139372c3a48ed98154b45cc6b9de17c789d5ab552e621c293609/cryptography-50.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:828743d939e9629bc267b8e2d08d8bb67cd4319c771a33d4b18b22dd8fb7440a", size = 4385197, upload-time = "2026-07-31T14:24:36.647Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/36/83bb81f6e569bc38e1e4a7bc80f29b46bb9601920bc455fc8e888f5d5742/cryptography-50.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:2a8183b489dc1f7f80f135780fadc1108f14b31b8a40411c7a5b17425f65f28b", size = 4748095, upload-time = "2026-07-31T14:24:39.493Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/16/d3008eff98c764979865834c3d386d4fd041b5f52e7f34fc29ac1a5eb515/cryptography-50.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6e7d61120573a7f2cd94cc095f9e81f6967c61ccdf194285aa143ecec8e0b708", size = 5325948, upload-time = "2026-07-31T14:24:41.556Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/f8/d97f9603efda3888187bfdb893f26c41be4735c10631d05d284ee6b047c4/cryptography-50.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:37fdb0d0111f1e2ff07139dfb79f1b49531f8e213c46f1163dd7642979b58c47", size = 4762400, upload-time = "2026-07-31T14:24:43.636Z" },
+    { url = "https://files.pythonhosted.org/packages/64/a2/4615c8f7d81a00b1d6e6afe19f694e1543582349fb5f4076f6cb5dc36485/cryptography-50.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c87f62a3d3b9888ed0fdde100ec06aa61ca9cd44bad9057d1dff9a516b5f5bb9", size = 4878208, upload-time = "2026-07-31T14:24:45.522Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/1a/efcfb02f91407149a0dacffffab791f7e19bf6385f63b3666dc8b5e5c9c8/cryptography-50.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:65c2c3add92b45fd0709db8594536aea39c2a67af0e27ffcf049c498501140b7", size = 5037050, upload-time = "2026-07-31T14:24:47.697Z" },
+    { url = "https://files.pythonhosted.org/packages/57/30/4a22984d4f1bdfb8c054f07a92bc176b97a3134cc1d6c4b3bffb1f3688b4/cryptography-50.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:d24fead1d4d076e1bfb006dcec392074a3cd8d7b4fc8a595aa64073b2b7a96ba", size = 3874135, upload-time = "2026-07-31T14:24:50.085Z" },
+]
+
+[[package]]
 name = "deform"
 version = "2.0.15"
 source = { registry = "https://pypi.org/simple" }
@@ -316,6 +366,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "cornice" },
+    { name = "cryptography" },
     { name = "deform" },
     { name = "numpy" },
     { name = "plaster-pastedeploy" },
@@ -346,6 +397,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "cornice", specifier = ">=6.1.0" },
+    { name = "cryptography", specifier = ">=42.0.0" },
     { name = "deform", specifier = ">=2.0.15" },
     { name = "numpy", specifier = ">=2.3.5" },
     { name = "plaster-pastedeploy", specifier = ">=1.0.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -50,6 +50,15 @@ wheels = [
 ]
 
 [[package]]
+name = "certifi"
+version = "2026.7.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
+]
+
+[[package]]
 name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -113,6 +122,67 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/54/ad/13262bad894f683782f61960baa0361de9075d30ffd8bcf55523a3ecec74/Chameleon-4.6.0.tar.gz", hash = "sha256:910cd729f6f7f38adad132ee51faa4f3ccc8344a6721aac31aa51a31f5781c1b", size = 181111, upload-time = "2024-12-31T11:19:49.255Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1b/44/07739ae778f280bb5d77806b57806730438331dd018268ff3a327a3507f6/Chameleon-4.6.0-py3-none-any.whl", hash = "sha256:f674cab262d7b8a26c38574e06f513e91f60c129887ff5ab6a3a2a46c03dd925", size = 88600, upload-time = "2024-12-31T11:19:59.35Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/2a/23f34ec9d04624958e137efdc394888716353190e75f25dd22c7a2c7a8aa/charset_normalizer-3.4.9.tar.gz", hash = "sha256:673611bbd43f0810bec0b0f028ddeaaa501190339cac411f347ac76917c3ae7b", size = 152439, upload-time = "2026-07-07T14:34:58.454Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/70/4a/ecbd131485c07fcdfad54e28946d513e3da22ef3b4bd854dcafae54ec739/charset_normalizer-3.4.9-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:45b0cc4e3556cd875e09102988d1ab8356c998b596c9fced84547c8138b487a0", size = 319300, upload-time = "2026-07-07T14:33:15.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/96/5d9364e3342d69f3a045e1777bc47c85c383e6e9466d561b33fdb419d1f9/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9b2aff1c7b3884512b9512c3eaadd9bab39fb45042ffaaa1dd08ff2b9f8109d9", size = 215802, upload-time = "2026-07-07T14:33:17.031Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/4c/5361f9aa7f2cb58d94f2ab831b3d493f69efb1d239654b4744e3c09527cb/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9104ed0bd76a429d46f9ec0dbc9b08ad1d2dcdf2b00a5a0daa1c145329b35b44", size = 237171, upload-time = "2026-07-07T14:33:18.576Z" },
+    { url = "https://files.pythonhosted.org/packages/50/78/ce342ca4ff30b2eb49fe6d9578df85974f90c67d294113e94efdd9664cbd/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7b86a2b16095d250c6f58b3d9b2eee6f4147754344f3dab0922f7c9bf7d226c9", size = 233075, upload-time = "2026-07-07T14:33:20.084Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c4/4fa4c8b3097a11f3c5f09a35b72ed6855fb1d332469504962ab7bafcc702/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e226f6218febc71f6c1fc2fafb91c226f75bdc1d8fb12d66823716e891608fd", size = 224256, upload-time = "2026-07-07T14:33:21.747Z" },
+    { url = "https://files.pythonhosted.org/packages/87/3a/ad914516df7e358a81aae018caa5e0470ba827fa6d763b1d2e87d920a5f6/charset_normalizer-3.4.9-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:90c44bc373b7687f6948b693cceaea1348ae0975d7474746559494468e3c1d84", size = 208784, upload-time = "2026-07-07T14:33:23.313Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/74/3c12f9755717dfe5c5c87da63f35d765fa0c00382ec26bf23f7fae34f2ba/charset_normalizer-3.4.9-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9cdef90ae47919cae358d8ab15797a800ed41da7aba5d72419fb510729e2ed4b", size = 219928, upload-time = "2026-07-07T14:33:24.814Z" },
+    { url = "https://files.pythonhosted.org/packages/33/9a/895095b83e7907abd6d3d99aad3a38ad0d9686cc186cb0c94c24320fe63e/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:60f44ade2cf573dad7a277e6f8ca9a51a21dda572b13bd7d8539bb3cd5dbedde", size = 218489, upload-time = "2026-07-07T14:33:26.42Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/34/ef5c05f412f42520d7709b7d3784d19640839eb7366ded1755511585429f/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:a1786910334ed46ab1dd73222f2cd1e05c2c3bb39f6dddb4f8b36fc382058a39", size = 210267, upload-time = "2026-07-07T14:33:27.952Z" },
+    { url = "https://files.pythonhosted.org/packages/83/dc/9b29fa4412b318bf3bfea985c35d67eb55e04b59a7c3f2237168b0e0be6f/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:03d07803992c6c7bbc976327f34b18b6160327fc81cb82c9d504720ac0be3b62", size = 226030, upload-time = "2026-07-07T14:33:29.397Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/42/6dbc00b8cd16011691203e33570fa42ed5746599a2e878112d16eab403a3/charset_normalizer-3.4.9-cp312-cp312-win32.whl", hash = "sha256:78841cccf1af7b40f6f716338d50c0902dbe88d9f800b3c973b7a9a0a693a642", size = 151185, upload-time = "2026-07-07T14:33:30.781Z" },
+    { url = "https://files.pythonhosted.org/packages/80/cc/f920afd1a23c58ccd53c1d36085a71893a4737ff5e66e0371efab6809850/charset_normalizer-3.4.9-cp312-cp312-win_amd64.whl", hash = "sha256:4b3dac63058cc36820b0dd072f89898604e2d39686fe05321729d00d8ac185a0", size = 162557, upload-time = "2026-07-07T14:33:32.176Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/e6/0386d43a261ff4e4b30c5857af7df877254b46bec7b9d1b74b6bf969a90b/charset_normalizer-3.4.9-cp312-cp312-win_arm64.whl", hash = "sha256:78fa18e436a1a0e58dbd7e02fc4473f3f32cceb12df9dfca542d075961c307d2", size = 152665, upload-time = "2026-07-07T14:33:33.711Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/06/97ec2aeae780b31d742b6352218b43841a6871e2564578ca522dce4a45c3/charset_normalizer-3.4.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:440eede837960000d74978f0eba527be106b5b9aee0daf779d395276ed0b0614", size = 317688, upload-time = "2026-07-07T14:33:35.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/39/8ff066c672434225f8d25f8b739f992af250944392173dcc88362681c9bf/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:21e764fd1e70b6a3e205a0e46f3051701f98a8cb3fad66eeb80e48bb502f8698", size = 214982, upload-time = "2026-07-07T14:33:36.996Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8f/3a47a3667c83c2df9483d91644c6c107de3bf8874aa1793da9d3012eb986/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e4fd89cc178bced6ad29cb3e6dd4aa63fa5017c3524dbd0b25998fb64a87cc8b", size = 236460, upload-time = "2026-07-07T14:33:38.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/60/b22cdbee7e4013dab8b0d7647fc6181120fbbbc8f7025c226d15bd5a47fc/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bd47ba7fc3ca94896759ea0109775132d3e7ab921fbf54038e1bab2e46c313c9", size = 232003, upload-time = "2026-07-07T14:33:40.059Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f8/72eb13dcabe7257035cea8aefd922caad2f110d252bf9f67c4c2ca763aee/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:84fd18bcc17526fc2b3c1af7d2b9217d32c9c04448c16ec693b9b4f1985c3d33", size = 223149, upload-time = "2026-07-07T14:33:41.631Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3e/faee8f9de92b14ee1198e9163252bb15efee7301b31256a3b6d9ebfdd0dd/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:5b10cd92fc5c498b35a8635df6d5a100207f88b63a4dc1de7ef9a548e1e2cd63", size = 207901, upload-time = "2026-07-07T14:33:43.209Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/25/45f30093ae27dd7b92a793b61882a38685f993700113ca36e0c9c14965e1/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a4fbdde9dd4a9ce5fd52c2b3a347bb50cc89483ef783f1cb00d408c13f7a96c0", size = 219176, upload-time = "2026-07-07T14:33:44.725Z" },
+    { url = "https://files.pythonhosted.org/packages/48/18/c8f397329c35e32f6a837e488986f4ae03bd2abebc453b48714991630c2f/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:416c229f77e5ea25b3dfd4b582f8d73d7e43c22320302b9ab128a2d3a0b38efe", size = 217356, upload-time = "2026-07-07T14:33:46.192Z" },
+    { url = "https://files.pythonhosted.org/packages/86/7e/5ce0bba863470fd1902d5e5843968951bddf38abe4742fc97116ef4598b3/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:75286256590a6320cf106a0d28970d3560aad9ee09aa7b34fb40524792436d35", size = 209614, upload-time = "2026-07-07T14:33:47.705Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/ef/2473d3c4d869155be4af1191111d59c4d5c4e0173026f7e85b176e23bf65/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:69b157c5d3292bcd443faca052f3096f637f1e074b98212a933c074ae23dc3b8", size = 224991, upload-time = "2026-07-07T14:33:49.238Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/a3/53ddae3db108a088156aa8ddfafd411ebbc1340f48c5573f697b27f69a39/charset_normalizer-3.4.9-cp313-cp313-win32.whl", hash = "sha256:51307f5c71007673a2bf8232ad973483d281e74cb99c8c5a990af1eefa6277d9", size = 150622, upload-time = "2026-07-07T14:33:50.711Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/ef/6953a77c7cf2c2ff9998e6f575ab3e380119f100223381565a4f94c1f836/charset_normalizer-3.4.9-cp313-cp313-win_amd64.whl", hash = "sha256:fe2c7201c642b7c308f1675355ad7ff7b66acfe3541625efe5a3ad38f29d6115", size = 161947, upload-time = "2026-07-07T14:33:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/fb/d560d1d1555debbfe7849d9cac6145c1b537709d79576bf22557ed803b82/charset_normalizer-3.4.9-cp313-cp313-win_arm64.whl", hash = "sha256:611057cc5d5c0afc743ba8be6bd828c17e0aaa8643f9d0a9b9bb7dea80eb8012", size = 152594, upload-time = "2026-07-07T14:33:53.486Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/8d/496817fa0944239ecae662dd57ea765cfeaec6a735f9f025d4b7b72e7143/charset_normalizer-3.4.9-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:0327fcd59a935777d83410750c50600ee9571af2846f71ce40f25b13da1ef380", size = 317253, upload-time = "2026-07-07T14:33:54.994Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/ef4a69ea338ad3c0deceea0f5f7d2380ae8b52132b06d652cb0d2cd86706/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a79d9f4d8001473a30c163556b3c3bfebec837495a412dde78b51672f6134f9", size = 215898, upload-time = "2026-07-07T14:33:56.334Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/e7/5ddfd76fc061eb52de219658a4aa431cbacadf0a0219c8854f00da50d289/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:33bdcc2a32c0a0e861f60841a512c8acc658c87c2ac59d89e3a46dacf7d866e4", size = 236718, upload-time = "2026-07-07T14:33:57.9Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ba/768fa3f36048d81c477a0ce61f813bc1454d80917ccfe550abd9f44f5e24/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f840ed6d8ecba8255df8c42b87fadeda98ddfc6eeec05e2dc66e26d46dd6f58a", size = 232519, upload-time = "2026-07-07T14:33:59.811Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/c4/b3e049d2aa3766180c78507110543d9d50894cc97f57de543f1be521dcdc/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c25fe15c70c59eb7c5ce8c06a1f3fa1da0ecc5ea1e7a5922c40fd2fa9b0d5046", size = 223143, upload-time = "2026-07-07T14:34:01.517Z" },
+    { url = "https://files.pythonhosted.org/packages/19/79/55c32d06d76ae4feafe053f061f3e3ab70bcf19f4007797ce8c3efda7830/charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:f7fb7d750cfa0a070d2c24e831fd3481019a60dd317ea2b39acbcebc08b6ed81", size = 206742, upload-time = "2026-07-07T14:34:03.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e0/47c079dd82d217c807479cd59ffd30af56307ea31c108b75758970459ad3/charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4d1c96a7a18b9690a4d46df09e3e3382406ae3213727cd1019ebade1c4a81917", size = 219191, upload-time = "2026-07-07T14:34:04.657Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ab/b9bc2e77d6b44a7e46ef62ec5cac1c9a6ba7b9135a5d560f002696ec9995/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a4cfde78a9f2880208d16a93b795726a3017d5977e08d1e162a7a31322479c41", size = 218328, upload-time = "2026-07-07T14:34:06.115Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/78/c9c71d599f5aa2d42bcdd35cbbd46d7f535351a57e40ff7d8e5a7e219401/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:d4d6fcde76f94f5cb9e43e9e9a61f16dacefd228cbbf6f1a09bd9b219a92f1a1", size = 207406, upload-time = "2026-07-07T14:34:07.554Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/39/c914445c321a845097ce4f6ac7de9a18228a77b766272125a1ce00d851eb/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:898f0e9068ca27d37f8e83a5b962821df851532e6c4a7d615c1c033f9da6eedf", size = 225157, upload-time = "2026-07-07T14:34:09.061Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/f2/c0d4b8508565a36bc5c624e88ed297f5b0b1095011034d7f5b83a69908b5/charset_normalizer-3.4.9-cp314-cp314-win32.whl", hash = "sha256:c1c948747b03be832dceed96ca815cef7360de9aa19d37c730f8e3f6101aca48", size = 151095, upload-time = "2026-07-07T14:34:10.901Z" },
+    { url = "https://files.pythonhosted.org/packages/49/fd/a1d26144398c67486422a72bf5812cda22cb4ccfcd95a290fb41ceb4b8e2/charset_normalizer-3.4.9-cp314-cp314-win_amd64.whl", hash = "sha256:16b65ea0f2465b6fb52aa22de5eca612aa964ddfec00a912e26f4656cbef890b", size = 162796, upload-time = "2026-07-07T14:34:12.47Z" },
+    { url = "https://files.pythonhosted.org/packages/20/95/d75e82f8ce9fd323ebf059c16c9aadefb22a1ecde13b7840b35835e4886c/charset_normalizer-3.4.9-cp314-cp314-win_arm64.whl", hash = "sha256:40a126142a56b2dfc0aacbad1de8310cbf60da7656db0e6b16eebd48e3e93519", size = 153334, upload-time = "2026-07-07T14:34:14.044Z" },
+    { url = "https://files.pythonhosted.org/packages/00/5e/17398df3a139985ba9d11ed072531986f408c8fca952835ef1ab1820c02b/charset_normalizer-3.4.9-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:609b3ba8fcc0fb5ab7af00719d0fb6ad0cb518e48e7712d12fd68f1327951198", size = 338848, upload-time = "2026-07-07T14:34:15.688Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/91/7253a32e86b7e1d1239b1b36ba6dd0f021a21107ab33054b53119cc083b9/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:51447e9aa2684679af07ca5021c3db526e0284347ebf4ffcec1154c3350cfe32", size = 223022, upload-time = "2026-07-07T14:34:17.248Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/32/2e64bd2be10e89c61e57ebe6a93fd98ae88eb7ebe414b5121f22c96c69eb/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cc1b0fff8ead343dae06305f954eb8468ba0ec1a97881f42489d198e4ce3c632", size = 241590, upload-time = "2026-07-07T14:34:18.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/ef/d96ec496cfea0c21db43b0ad03891308b02388d054cc902cf0e5a1ad6a88/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fa36ec09ef71d158186bc79e359ff5fdd6e7996fe8ab638f00d6b93139ba4fcf", size = 239584, upload-time = "2026-07-07T14:34:20.52Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/ce/9af95f7876194bd7a14e3dfe4a4de2e0bff02666a3910d72beafd06cc297/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:df115d4d83168fdf2cae48ef1ff6d1cb4c466364e30861b37121de0f3bf1b990", size = 230224, upload-time = "2026-07-07T14:34:22.189Z" },
+    { url = "https://files.pythonhosted.org/packages/52/94/af74dde74a3996bd959c350709bfe50e297823d70a8c1cbd54b838880863/charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f86c6358749bd4fda175388691e3ba8c46e24c5347d0afd20f9b7edfc9faf07d", size = 212667, upload-time = "2026-07-07T14:34:23.857Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f0/f1c4fe746c395922961b5916ed1d7d6e7d4c84851d19ed43cc89980ec953/charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:32286a2c8d167e897177b673176c1e3e00d4057caf5d2b64eef9a3666b03018e", size = 227179, upload-time = "2026-07-07T14:34:25.586Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/56/6c745619ac397e8871e2bcd3cea1eec86b877488f33888b3aef5c3ed506e/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:83aed2c10721ddd90f68140685391b50811a880af20654c59af6b6c66c40513c", size = 225372, upload-time = "2026-07-07T14:34:27.212Z" },
+    { url = "https://files.pythonhosted.org/packages/78/ad/98aae8630ac71f16711968e38a5acfecce41b778bf2f0312851020f565a8/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cd6c3d4b783c556fa00bf540854e42f135e2f256abd29669fcd0da0f2dec79c2", size = 215222, upload-time = "2026-07-07T14:34:28.774Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/40/9593d54209765207a7f11073c06494c1721e4ca4a0a426c597679bf7f91e/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ee2f2a527e3c1a6e6411eb4209642e138b544a2d72fe5d0d76daf77b24063534", size = 231958, upload-time = "2026-07-07T14:34:30.345Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/27/693ee5e8a18191eb38647360c51cd505013e2bd3b366aa43fd5344c21e3c/charset_normalizer-3.4.9-cp314-cp314t-win32.whl", hash = "sha256:0d861473f743244d349b50f850d10eb87aeb22bbdcc8e64f79273c94af5a8226", size = 155580, upload-time = "2026-07-07T14:34:31.884Z" },
+    { url = "https://files.pythonhosted.org/packages/80/3f/bd97d3d9c613013d07cb7733d299385b41df37f0471310f5a73dc359f0b8/charset_normalizer-3.4.9-cp314-cp314t-win_amd64.whl", hash = "sha256:9b8e0f3107e2200b76f6054de99016eac3ee6762713587b36baaa7e4bd2ae177", size = 167620, upload-time = "2026-07-07T14:34:33.438Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/c6/eee9dca4439b1061f76373f06ea855678cc4a64c1c3c90b50e479edbb8eb/charset_normalizer-3.4.9-cp314-cp314t-win_arm64.whl", hash = "sha256:19ac87f93086ce37b86e098888555c4b4bc48102279bae3350098c0ed664b501", size = 158037, upload-time = "2026-07-07T14:34:35.018Z" },
+    { url = "https://files.pythonhosted.org/packages/98/2b/f97f1c193fb855c345d678f5077d6926034db0722df74c8f057020e05a25/charset_normalizer-3.4.9-py3-none-any.whl", hash = "sha256:68e5f26a1ad57ded6d1cfb85331d1c1a195314756471d97758c48498bb4dcdf5", size = 64538, upload-time = "2026-07-07T14:34:56.993Z" },
 ]
 
 [[package]]
@@ -256,6 +326,7 @@ dependencies = [
     { name = "pyramid-storage" },
     { name = "pyramid-tm" },
     { name = "pyramid-zodbconn" },
+    { name = "requests" },
     { name = "scipy" },
     { name = "transaction" },
     { name = "waitress" },
@@ -285,6 +356,7 @@ requires-dist = [
     { name = "pyramid-storage", specifier = ">=1.3.2" },
     { name = "pyramid-tm", specifier = ">=2.6" },
     { name = "pyramid-zodbconn", specifier = ">=0.8.1" },
+    { name = "requests", specifier = ">=2.31.0" },
     { name = "scipy", specifier = ">=1.16.3" },
     { name = "transaction", specifier = ">=5.0" },
     { name = "waitress", specifier = ">=3.0.2" },
@@ -306,6 +378,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bd/e6/bb064537288eee2be97f3e0fcad8e7242bc5bbe9664ae57c7d29b3fa18c2/hupper-1.12.1.tar.gz", hash = "sha256:06bf54170ff4ecf4c84ad5f188dee3901173ab449c2608ad05b9bfd6b13e32eb", size = 43231, upload-time = "2024-01-26T09:14:57.294Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/86/7d/3888833e4f5ea56af4a9935066ec09a83228e533d7b8877f65889d706ee4/hupper-1.12.1-py3-none-any.whl", hash = "sha256:e872b959f09d90be5fb615bd2e62de89a0b57efc037bdf9637fb09cdf8552b19", size = 22830, upload-time = "2024-01-26T09:14:55.176Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -757,6 +838,21 @@ wheels = [
 ]
 
 [[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
 name = "rich"
 version = "14.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -876,6 +972,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- GameData model (interactions/badges read-only, stats/preferences read-write) persisted on BeeHive
- New GET /api/v1/me and GET/POST /api/v1/games/{nodeid}/data endpoints
- Homologated JS SDK (honeycomb/static/sdk/honeycomb.js)
- Tests for the new endpoints and model; fixes a pre-existing broken test that blocked the whole suite
- Docs at docs/comunicacion-videojuegos-api.md


## Test plan
- [x] uv run pytest (20 passed, 1 pre-existing unrelated failure: test_root)
- [x] Manually exercised with curl against a running dev server (login, /me, GET/POST game data, merge behavior, server ignores client-supplied interactions)